### PR TITLE
Replace Rectangles with more appropriate UI elements

### DIFF
--- a/geometry_constructor/Qt models/PixelControls.qml
+++ b/geometry_constructor/Qt models/PixelControls.qml
@@ -4,8 +4,7 @@ import Qt.labs.platform 1.0
 import MyWriters 1.0
 import MyModels 1.0
 
-Rectangle {
-    anchors.margins:2
+Pane {
 
     Row {
         id: textRow
@@ -43,11 +42,12 @@ Rectangle {
         }
     }
 
-    Rectangle {
+    Frame {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: facesRow.bottom
         anchors.bottom: writeButtonRow.top
+        padding: 1
         ListView {
             id: pixelListView
             objectName: "pixelListView"
@@ -55,12 +55,6 @@ Rectangle {
             delegate: pixelDelegate
             anchors.fill: parent
             clip: true
-        }
-        Rectangle {
-            anchors.fill: parent
-            border.width: 1
-            border.color: "black"
-            color: "transparent"
         }
     }
 
@@ -118,66 +112,73 @@ Rectangle {
 
     Component {
         id: pixelDelegate
-        Rectangle {
+        Frame {
             id: pixelBox
-            height: 45
-            border.width: 1
-            border.color: "black"
+            padding: 5
+            contentHeight: mainContent.height + extendedContent.height
             width: pixelListView.width
+
             MouseArea {
-                anchors.fill: pixelBox
+                anchors.fill: parent
                 onClicked: pixelBox.state = (pixelBox.state == "Extended") ? "" : "Extended"
             }
-            Text {
-                id: nameLabel
+
+            Item {
+                id: mainContent
                 anchors.left: parent.left
-                anchors.top: parent.top
-                anchors.margins: 2
-                width: 100
-                text: "<b>Name:</b>" + name
-            }
-            Text {
-                id: faceLabel
-                anchors.left: nameLabel.right
-                anchors.right: removeButton.left
-                anchors.top: parent.top
-                anchors.margins: 2
-                width: 185
-                text: "<b>Faces:</b>" + faces.join(", ")
-            }
-            Button {
-                id: removeButton
-                anchors.right: expansionCaret.left
-                anchors.top: parent.top
-                anchors.margins: 2
-                text: "Remove"
-                objectName: "removePixelButton"
-                onClicked: pixelData.remove_pixel(index)
-                background: Rectangle {
-                    border.color: "#f00"
-                    border.width: parent.pressed ? 2 : 1
-                    radius: 8
-                    // darker button when hovered-over, or tab-selected
-                    color: (parent.hovered || parent.activeFocus) ? "#f88" : "#faa"
+                anchors.right: parent.right
+                height: removeButton.height
+                Text {
+                    id: nameLabel
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    width: 100
+                    text: "<b>Name:</b>" + name
+                }
+                Text {
+                    id: faceLabel
+                    anchors.left: nameLabel.right
+                    anchors.right: removeButton.left
+                    anchors.top: parent.top
+                    width: 185
+                    text: "<b>Faces:</b>" + faces.join(", ")
+                }
+                Button {
+                    id: removeButton
+                    anchors.right: expansionCaret.left
+                    anchors.rightMargin: 5
+                    anchors.top: parent.top
+                    text: "Remove"
+                    objectName: "removePixelButton"
+                    onClicked: pixelData.remove_pixel(index)
+                    background: Rectangle {
+                        border.color: "#f00"
+                        border.width: parent.pressed ? 2 : 1
+                        radius: 8
+                        // darker button when hovered-over, or tab-selected
+                        color: (parent.hovered || parent.activeFocus) ? "#f88" : "#faa"
+                    }
+                }
+                Image {
+                    id: expansionCaret
+                    width: 20; height: 20;
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    source: "file:images/caret.svg"
+                    transformOrigin: Item.Center
+                    rotation: 0
                 }
             }
-            Image {
-                id: expansionCaret
-                width: 20; height: 20;
-                anchors.right: parent.right
-                anchors.top: parent.top
-                anchors.margins: 2
-                source: "file:images/caret.svg"
-                transformOrigin: Item.Center
-                rotation: 0
-            }
 
-            Rectangle {
+            Item {
                 id: extendedContent
+                anchors.top: mainContent.bottom
                 anchors.left: parent.left
-                anchors.top: removeButton.bottom
+                anchors.right: parent.right
+                height: 0
                 visible: false
                 Text{
+                    id: extendedText
                     text: "I have been extended"
                 }
             }
@@ -185,7 +186,7 @@ Rectangle {
             states: State {
                 name: "Extended"
 
-                PropertyChanges { target: pixelBox; height: 80 }
+                PropertyChanges { target: extendedContent; height: extendedText.height }
                 PropertyChanges { target: extendedContent; visible: true }
                 PropertyChanges { target: expansionCaret; rotation: 180 }
             }

--- a/geometry_constructor/Qt models/main.qml
+++ b/geometry_constructor/Qt models/main.qml
@@ -1,33 +1,37 @@
 import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtQuick.Scene3D 2.0
 
-Rectangle {
+Pane {
     width: 700
     height: 300
+    padding: 5
+    focus: true
 
     PixelControls {
         id: pixelFieldsArea
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
+        leftPadding: 0
 
-        width: 355;
+        width: 365;
     }
 
-    Rectangle {
+    Frame {
         id: instrumentViewArea
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: pixelFieldsArea.right
         anchors.right: parent.right
-        anchors.margins: 10
-        border.width: 1
-        border.color: "black"
+        contentWidth: scene3d.implicitWidth
+        contentHeight: scene3d.implicitHeight
+        focus: true
+        padding: 1
 
         Scene3D {
             id: scene3d
             anchors.fill: parent
-            anchors.margins: 1
             focus: true
             aspects: ["input", "logic"]
             cameraAspectRatioMode: Scene3D.AutomaticAspectRatio
@@ -36,9 +40,9 @@ Rectangle {
         }
 
         MouseArea {
-            anchors.fill: parent
-            onClicked: scene3d.focus = true
-            enabled: !scene3d.focus
+            anchors.fill: scene3d
+            onClicked: instrumentViewArea.focus = true
+            enabled: !instrumentViewArea.focus
         }
     }
 }


### PR DESCRIPTION
Closes #24 
Replaces Rectangles in the UI with Panes, Frames and Items where appropriate.
Frames are Panes that come with a built in border, but neither pass events to elements behind them, so Items are used in some places instead.

Frames and Panes also act as [focus scopes](https://doc.qt.io/qt-5/qtquickcontrols2-focus.html), so additional focus properties have been added to make sure the 3D visualisation can start with, and be reassigned, keyboard control.

![image](https://user-images.githubusercontent.com/2938284/46346777-19a1ad00-c641-11e8-94c7-a59cc3aa0e8f.png)
