### PR TITLE
Add a schema for the generated json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ venv.bak/
 
 # Saved JSON files
 *.json
+
+# Allow JSON schemas
+!*.schema.json

--- a/Instrument.schema.json
+++ b/Instrument.schema.json
@@ -1,0 +1,300 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "https://raw.githubusercontent.com/ess-dmsc/nexus-geometry-constructor/master/Instrument.schema.json",
+  "title": "Instrument",
+  "description": "An experimental setup of an instrument on a beamline, containing a sample and set of components based on the NeXus data format",
+  "type": "object",
+  "properties": {
+    "sample": {
+      "description": "The sample being experimented on",
+      "$ref": "#/definitions/sample"
+    },
+    "components": {
+      "description": "The components that make up the instrument",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/detector"
+      }
+    }
+  },
+  "required": ["sample", "components"],
+  "definitions": {
+    "3D": {
+      "description": "XYZ values representing a direction or point in 3D space",
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        }
+      },
+      "required": ["x", "y", "z"]
+    },
+    "component": {
+      "description": "A component in an instrument",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "transform_id": {
+          "type": "integer"
+        },
+        "transform_parent_id": {
+          "type": "integer"
+        },
+        "transforms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/transform"
+          }
+        },
+        "geometry": {
+          "$ref": "#/definitions/geometry"
+        }
+      },
+      "required": [ "name", "description", "type", "transform_id", "transforms" ]
+    },
+    "sample": {
+      "description": "The sample in an instrument",
+      "allOf": [
+        {"$ref": "#/definitions/component"}
+      ],
+      "properties": {
+        "type": {
+          "enum": [ "Sample" ]
+        }
+      },
+      "required": [ "type" ]
+    },
+    "detector": {
+      "description": "Detector components of an instrument",
+      "allOf": [
+        {"$ref": "#/definitions/component"}
+      ],
+      "properties": {
+        "type": {
+          "enum": [ "Detector" ]
+        }
+      },
+      "oneOf": [
+        {"$ref": "#/definitions/pixelMappedDetectorProperties"},
+        {"$ref": "#/definitions/repeatedPixelDetectorProperties"}
+      ]
+    },
+    "pixelMappedDetectorProperties": {
+      "description": "Properties for a detector with a pixelmapping, meaning it must have an OFF geometry",
+      "properties": {
+        "geometry": {
+          "$ref": "#/definitions/offGeometry"
+        },
+        "pixel_mapping": {
+          "$ref": "#/definitions/pixelMapping"
+        }
+      },
+      "required": [ "geometry", "pixel_mapping" ]
+    },
+    "repeatedPixelDetectorProperties": {
+      "description": "Properties for a detector with a repeated pixel geometry. Unlike a pixel mapping, no further geometry restrictions are needed",
+      "properties": {
+        "pixel_grid": {
+          "$ref": "#/definitions/pixelGrid"
+        }
+      },
+      "required": [ "pixel_grid" ]
+    },
+    "transform": {
+      "description": "A transformation to position an object in 3D space",
+      "oneOf": [
+        { "$ref": "#/definitions/rotate" },
+        { "$ref": "#/definitions/translate" }
+      ]
+    },
+    "rotate": {
+      "description": "A transformation in 3D space by rotating about an axis",
+      "properties": {
+        "type": {
+          "enum": [ "rotate" ]
+        },
+        "axis": {
+          "$ref": "#/definitions/3D"
+        },
+        "angle": {
+          "type": "object",
+          "properties": {
+            "unit": {
+              "enum": [ "degrees" ]
+            },
+            "value": {
+              "type": "number"
+            }
+          },
+          "required": [ "unit", "value" ]
+        }
+      },
+      "required": [ "type", "axis", "angle" ]
+    },
+    "translate": {
+      "description": "A transformation in 3D space by translating along a vector",
+      "properties": {
+        "type": {
+          "enum": [ "translate" ]
+        },
+        "vector": {
+          "$ref": "#/definitions/3D"
+        },
+        "unit": {
+          "enum": [ "m" ]
+        }
+      },
+      "required": [ "type", "vector", "unit" ]
+    },
+    "geometry": {
+      "description": "The 3D geometry of a component in the instrument",
+      "oneOf": [
+        { "$ref": "#/definitions/offGeometry" },
+        { "$ref": "#/definitions/cylindricalGeometry" }
+      ]
+    },
+    "offGeometry": {
+      "description": "A geometry of arbitrary polygons based on the NXoff_geometry class",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [ "OFF" ]
+        },
+        "vertices": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "winding_order": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "faces": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
+      "required": [ "type", "vertices", "winding_order", "faces" ]
+    },
+    "cylindricalGeometry": {
+      "description": "A geometry to model a cylinder with center of its base at the origin of its local coordinate system",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [ "Cylinder" ]
+        },
+        "axis_direction": {
+          "$ref": "#/definitions/3D"
+        },
+        "height": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "radius": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "base_center": {
+          "$ref": "#/definitions/3D"
+        },
+        "base_edge": {
+          "$ref": "#/definitions/3D"
+        },
+        "top_center": {
+          "$ref": "#/definitions/3D"
+        }
+      },
+      "required": [ "type", "axis_direction", "height", "radius", "base_center", "base_edge", "top_center" ]
+    },
+    "pixelData": {
+      "description": "How pixels in a detector are arranged",
+      "oneOf": [
+        { "$ref": "#/definitions/pixelGrid" },
+        { "$ref": "#/definitions/pixelMapping" }
+      ]
+    },
+    "pixelGrid": {
+      "description": "A regular grid of pixels, starting in the bottom left corner, which is the local coordinate origin",
+      "type": "object",
+      "properties": {
+        "rows": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "columns": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "row_height": {
+          "type": "number"
+        },
+        "column_width": {
+          "type": "number"
+        },
+        "first_id": {
+          "type": "integer"
+        },
+        "count_direction": {
+          "$ref": "#/definitions/countDirection"
+        },
+        "starting_corner": {
+          "$ref": "#/definitions/corner"
+        }
+      },
+      "required": [ "rows", "columns", "row_height", "column_width", "first_id", "count_direction", "starting_corner" ]
+    },
+    "pixelMapping": {
+      "description": "A mapping of off geometry face numbers to detector id's, mirroring the detector_faces property of the NXoff_geometry class",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "face": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pixel_id": {
+            "type": "integer"
+          }
+        },
+        "required": [ "face", "pixel_id" ]
+      }
+    },
+    "countDirection": {
+      "description": "The direction a pixelGrid should increment its detector ID's along first",
+      "enum": [ "ROW", "COLUMN" ]
+    },
+    "corner": {
+      "description": "A corner of a 2D grid",
+      "enum": [ "TOP_LEFT", "TOP_RIGHT", "BOTTOM_LEFT", "BOTTOM_RIGHT" ]
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ h5py==2.8.0
 flake8==3.5.0
 cx_Freeze==5.1.1
 git+https://github.com/ess-dmsc/python-nexus-utilities@6f5d2c7f1ca66063227aad2a111a2cc567d573f6#egg=nexusutils
+jsonschema==2.6.0

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,3 +1,5 @@
+import json
+import jsonschema
 from geometry_constructor.data_model import Detector, CylindricalGeometry, PixelMapping, PixelGrid, Vector,\
     CountDirection, Corner
 from geometry_constructor.geometry_models import OFFModel
@@ -7,7 +9,7 @@ from geometry_constructor.json_loader import JsonLoader
 from PySide2.QtCore import QUrl
 
 
-def test_loading_generated_json():
+def build_sample_model():
     model = InstrumentModel()
 
     offmodel = OFFModel()
@@ -41,6 +43,12 @@ def test_loading_generated_json():
     model.components[1].transform_parent = model.components[0]
     model.components[2].transform_parent = model.components[1]
 
+    return model
+
+
+def test_loading_generated_json():
+    model = build_sample_model()
+
     assert model.components == model.components
 
     json = JsonWriter().generate_json(model)
@@ -49,3 +57,14 @@ def test_loading_generated_json():
     JsonLoader().load_json_into_instrument_model(json, loaded_model)
 
     assert model.components == loaded_model.components
+
+
+def test_json_schema_compliance():
+    with open('Instrument.schema.json') as file:
+        schema = json.load(file)
+
+    model = build_sample_model()
+    model_json = JsonWriter().generate_json(model)
+    model_data = json.loads(model_json)
+
+    jsonschema.validate(model_data, schema)


### PR DESCRIPTION
Gives us a definition to the format of the generated json that's independent of the generator code. Should be useful when adapting the nexus file writer to add the geometry data from json.

The shema I've written uses v4 of the json schema draft proposal, as thats the version supported by the current stable branch of the jsonschema python library. There is a recent beta version being worked on with support for the current draft (v7), so if this merges I'll raise an issue to update versions when that library updates.