### PR TITLE
Input validation

### DIFF
--- a/geometry_constructor/application.py
+++ b/geometry_constructor/application.py
@@ -11,6 +11,7 @@ from geometry_constructor.geometry_models import CylinderModel, OFFModel
 from geometry_constructor.json_loader import JsonLoader
 from geometry_constructor.json_writer import JsonWriter
 from geometry_constructor.qml_json_model import FilteredJsonModel
+from geometry_constructor.validators import NameValidator, TransformParentValidator
 from geometry_constructor.writers import HdfWriter, Logger
 from PySide2.QtCore import QUrl, QObject
 from PySide2.QtQml import QQmlApplicationEngine, qmlRegisterType
@@ -24,6 +25,8 @@ qmlRegisterType(OFFModel, 'MyModels', 1, 0, 'OFFModel')
 qmlRegisterType(FilteredJsonModel, 'MyModels', 1, 0, 'FilteredJsonModel')
 qmlRegisterType(JsonLoader, 'MyJson', 1, 0, 'JsonLoader')
 qmlRegisterType(JsonWriter, 'MyJson', 1, 0, 'JsonWriter')
+qmlRegisterType(NameValidator, 'MyValidators', 1, 0, 'NameValidator')
+qmlRegisterType(TransformParentValidator, 'MyValidators', 1, 0, 'ParentValidator')
 
 
 class Application(QQmlApplicationEngine):

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -96,8 +96,7 @@ class InstrumentModel(QAbstractListModel):
                 lambda: self.components.index(component.transform_parent)
                 if component.transform_parent in self.components
                 else 0,
-            InstrumentModel.PixelDataRole:
-                lambda: component.pixel_data if isinstance(component, Detector) else None,
+            InstrumentModel.PixelDataRole: lambda: component.pixel_data if isinstance(component, Detector) else None,
             InstrumentModel.GeometryRole: lambda: component.geometry,
             InstrumentModel.MeshRole: lambda: self.meshes[row],
             InstrumentModel.TransformMatrixRole: lambda: self.generate_matrix(component),

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -252,7 +252,7 @@ class InstrumentModel(QAbstractListModel):
     @Slot(str, result=str)
     def generate_component_name(self, base):
         """Generates a unique name for a new component using a common base string"""
-        regex = '^{}\d*$'.format(base)
+        regex = '^{}\d*$'.format(re.escape(base))
         similar_names = [component.name for component in self.components if re.match(regex, component.name)]
 
         if len(similar_names) == 0 or base not in similar_names:

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -3,6 +3,7 @@ from geometry_constructor.data_model import Sample, Detector, PixelGrid, CountDi
 from geometry_constructor.off_renderer import OffMesh
 from PySide2.QtCore import Qt, QAbstractListModel, QModelIndex, Signal, Slot
 from PySide2.QtGui import QMatrix4x4, QVector3D
+import re
 
 
 class InstrumentModel(QAbstractListModel):
@@ -247,3 +248,17 @@ class InstrumentModel(QAbstractListModel):
                 model_index = self.createIndex(i, 0)
                 self.dataChanged.emit(model_index, model_index, InstrumentModel.TransformMatrixRole)
                 self.update_child_transforms(candidate)
+
+    @Slot(str, result=str)
+    def generate_component_name(self, base):
+        """Generates a unique name for a new component using a common base string"""
+        regex = '^{}\d*$'.format(base)
+        similar_names = [component.name for component in self.components if re.match(regex, component.name)]
+
+        if len(similar_names) == 0 or base not in similar_names:
+            return base
+        if similar_names == [base]:
+            return base + '1'
+        # find the highest number in use, and go one higher
+        tailing_numbers = [int(name[len(base):]) for name in similar_names if name != base]
+        return base + str(max(tailing_numbers) + 1)

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -46,6 +46,7 @@ class InstrumentModel(QAbstractListModel):
     GeometryRole = Qt.UserRole + 12
     MeshRole = Qt.UserRole + 13
     TransformMatrixRole = Qt.UserRole + 14
+    RemovableRole = Qt.UserRole + 15
 
     def __init__(self):
         super().__init__()
@@ -101,6 +102,7 @@ class InstrumentModel(QAbstractListModel):
             InstrumentModel.GeometryRole: lambda: component.geometry,
             InstrumentModel.MeshRole: lambda: self.meshes[row],
             InstrumentModel.TransformMatrixRole: lambda: self.generate_matrix(component),
+            InstrumentModel.RemovableRole: lambda: self.is_removable(row),
         }
         if role in accessors:
             return accessors[role]()
@@ -132,6 +134,8 @@ class InstrumentModel(QAbstractListModel):
             changed = self.change_value(*param_list)
         if changed:
             self.dataChanged.emit(index, index, role)
+            if role == InstrumentModel.TransformParentIndexRole:
+                self.update_removable()
         return changed
 
     def change_value(self, item, attribute_name, value, transforms):
@@ -161,6 +165,7 @@ class InstrumentModel(QAbstractListModel):
             InstrumentModel.PixelDataRole: b'pixel_data',
             InstrumentModel.MeshRole: b'mesh',
             InstrumentModel.TransformMatrixRole: b'transform_matrix',
+            InstrumentModel.RemovableRole: b'removable'
         }
 
     @Slot(str)
@@ -184,16 +189,16 @@ class InstrumentModel(QAbstractListModel):
         self.components.append(detector)
         self.meshes.append(self.generate_mesh(detector))
         self.endInsertRows()
+        self.update_removable()
 
     @Slot(int)
     def remove_component(self, index):
-        # Don't let the initial sample be removed
-        if index == 0:
-            return
-        self.beginRemoveRows(QModelIndex(), index, index)
-        self.components.pop(index)
-        self.meshes.pop(index)
-        self.endRemoveRows()
+        if self.is_removable(index):
+            self.beginRemoveRows(QModelIndex(), index, index)
+            self.components.pop(index)
+            self.meshes.pop(index)
+            self.endRemoveRows()
+            self.update_removable()
 
     @Slot(int, 'QVariant')
     def set_geometry(self, index, geometry_model):
@@ -262,3 +267,19 @@ class InstrumentModel(QAbstractListModel):
         # find the highest number in use, and go one higher
         tailing_numbers = [int(name[len(base):]) for name in similar_names if name != base]
         return base + str(max(tailing_numbers) + 1)
+
+    def is_removable(self, index: int):
+        """
+        Determine if a component can be removed from the model
+
+        The initial sample should never be removable, and neither should transform parents of other components.
+        """
+        if index == 0:
+            return False
+        component = self.components[index]
+        return len([c for c in self.components if c.transform_parent is component and c is not component]) == 0
+
+    def update_removable(self):
+        self.dataChanged.emit(self.createIndex(0, 0),
+                              self.createIndex(len(self.components), 0),
+                              InstrumentModel.RemovableRole)

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -62,9 +62,13 @@ class TransformParentValidator(ValidatorOnInstrumentModel):
 
         The signal 'validationFailed' is emitted only if a circular dependency is found
         (http://doc.qt.io/qt-5/qvalidator.html#validate)
+        :param input: The name of the component being considered for assignment as a transform parent
+        :param pos: The cursor position in input. Required to match the QValidator API, and not used.
         """
-        parents = {}
 
+        # A mapping of component indexes to the indexes of their parents
+        parents = {}
+        # Build the parents mapping, including the mapping that would be set by the new assignment
         candidate_parent_index = -1
         for component in self.instrument_model.components:
             index = self.instrument_model.components.index(component)
@@ -82,6 +86,7 @@ class TransformParentValidator(ValidatorOnInstrumentModel):
 
         visited = {self.model_index}
         index = self.model_index
+        # Explore the parent mapping as a graph until all connections have been explored or a loop is found
         for _ in range(len(parents)):
             parent_index = parents[index]
             if parent_index == index:

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -1,0 +1,112 @@
+"""Input validators to be used on QML input fields"""
+from geometry_constructor.instrument_model import InstrumentModel
+from PySide2.QtCore import Property, Signal
+from PySide2.QtGui import QValidator
+
+
+class ValidatorOnInstrumentModel(QValidator):
+    """
+    Base class for validators that check an indexed item against other components in an InstrumentModel
+
+    Exposes properties that can be set in QML for the component index, and instrument model.
+    In QML these can be set with 'myindex' and 'model'
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.instrument_model = InstrumentModel(include_default_geometry=False)
+        self.model_index = -1
+
+    def get_index(self):
+        return self.model_index
+
+    def set_index(self, val: int):
+        self.model_index = val
+
+    @Signal
+    def index_changed(self):
+        pass
+
+    myindex = Property(int, get_index, set_index, notify=index_changed)
+
+    def get_model(self):
+        return self.instrument_model
+
+    def set_model(self, val: InstrumentModel):
+        self.instrument_model = val
+
+    @Signal
+    def model_changed(self):
+        pass
+
+    model = Property('QVariant', get_model, set_model, notify=model_changed)
+
+
+class TransformParentValidator(ValidatorOnInstrumentModel):
+    """
+    Validator to prevent circular transform parent dependencies being created in an instrument model
+
+    Getters and setters, while un-pythonic, are required for the Qt properties system
+    https://wiki.qt.io/Qt_for_Python_UsingQtProperties
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def validate(self, input: str, pos: int):
+        """
+        Validates the input as the name of a component's transform parent to check it won't cause a circular dependency
+
+        (http://doc.qt.io/qt-5/qvalidator.html#validate)
+        """
+        parents = {}
+
+        candidate_parent_index = -1
+        for component in self.instrument_model.components:
+            index = self.instrument_model.components.index(component)
+            if component.transform_parent is None:
+                parent_index = 0
+            else:
+                parent_index = self.instrument_model.components.index(component.transform_parent)
+            parents[index] = parent_index
+            if component.name == input:
+                candidate_parent_index = index
+        if candidate_parent_index == -1:
+            # input is not a valid parent name
+            return QValidator.Invalid
+        parents[self.model_index] = candidate_parent_index
+
+        visited = {self.model_index}
+        index = self.model_index
+        for _ in range(len(parents)):
+            parent_index = parents[index]
+            if parent_index == index:
+                # self looping, acceptable end of tree
+                return QValidator.Acceptable
+            if parent_index in visited:
+                # loop found
+                return QValidator.Invalid
+            visited.add(parent_index)
+            index = parent_index
+        # A result should have been found in the loop. Fail the validation
+        return QValidator.Invalid
+
+
+class NameValidator(ValidatorOnInstrumentModel):
+    """
+    Validator to ensure component names are unique within a model
+
+    Names must be unique as they are used to identify component objects in generated NeXus files, which must be named
+    uniquely.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def validate(self, input: str, pos: int):
+        components = self.instrument_model.components
+        # if any other component has the same name, it's invalid for this component
+        for component in (components[i] for i in range(len(components)) if i != self.model_index):
+            if component.name == input:
+                return QValidator.Invalid
+        return QValidator.Acceptable

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -14,7 +14,7 @@ class ValidatorOnInstrumentModel(QValidator):
 
     def __init__(self):
         super().__init__()
-        self.instrument_model = InstrumentModel(include_default_geometry=False)
+        self.instrument_model = InstrumentModel()
         self.model_index = -1
 
     def get_index(self):

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -10,6 +10,9 @@ class ValidatorOnInstrumentModel(QValidator):
 
     Exposes properties that can be set in QML for the component index, and instrument model.
     In QML these can be set with 'myindex' and 'model'
+
+    Getters and setters, while un-pythonic, are required for the Qt properties system
+    https://wiki.qt.io/Qt_for_Python_UsingQtProperties
     """
 
     def __init__(self):
@@ -45,9 +48,6 @@ class ValidatorOnInstrumentModel(QValidator):
 class TransformParentValidator(ValidatorOnInstrumentModel):
     """
     Validator to prevent circular transform parent dependencies being created in an instrument model
-
-    Getters and setters, while un-pythonic, are required for the Qt properties system
-    https://wiki.qt.io/Qt_for_Python_UsingQtProperties
     """
 
     def __init__(self):

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -2,6 +2,7 @@ import QtQuick 2.11
 import QtQuick.Window 2.11
 import QtQuick.Controls 2.4
 import MyModels 1.0
+import MyValidators 1.0
 
 Window {
 
@@ -15,6 +16,8 @@ Window {
     property real translate_x: 0
     property real translate_y: 0
     property real translate_z: 0
+
+    property int index: -1
 
     title: "Add Detector"
     id: addDetectorWindow
@@ -80,6 +83,10 @@ Window {
                 labelText: "Name:"
                 editorText: name
                 onEditingFinished: name = editorText
+                validator: NameValidator {
+                    model: components
+                    myindex: -1
+                }
             }
 
             LabeledTextField {

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -52,6 +52,7 @@ Window {
                 text: "Repeatable OFF"
                 onClicked: {
                     geometryControls.state = "OFF"
+                    name = components.generate_component_name("Detector")
                     contentPane.state = "EnterDetails"
                 }
             }
@@ -62,6 +63,7 @@ Window {
                 text: "Repeatable Cylinder"
                 onClicked: {
                     geometryControls.state = "Cylinder"
+                    name = components.generate_component_name("Detector")
                     contentPane.state = "EnterDetails"
                 }
             }

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -6,7 +6,7 @@ import MyValidators 1.0
 
 Window {
 
-    property string name: "Detector"
+    property string name: components.generate_component_name("Component")
     property string description: ""
     property real transform_parent_index: 0
     property real rotate_x: 0

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -88,6 +88,9 @@ Window {
                 validator: NameValidator {
                     model: components
                     myindex: -1
+                    onValidationFailed: {
+                        nameField.ToolTip.show("Component names must be unique", 3000)
+                    }
                 }
             }
 

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -152,9 +152,12 @@ Pane {
                         width: parent.width / 4
                         text: "Delete"
                         onClicked: components.remove_component(index)
-                        enabled: removable
+                        buttonEnabled: removable
                         // The sample (at index 0) should never be removed. Don't even show it as an option.
                         visible: index != 0
+                        ToolTip.visible: hovered & !removable
+                        ToolTip.delay: 400
+                        ToolTip.text: "Cannot remove a component that's in use as a transform parent"
                     }
                 }
             }

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -152,6 +152,9 @@ Pane {
                         width: parent.width / 4
                         text: "Delete"
                         onClicked: components.remove_component(index)
+                        enabled: removable
+                        // The sample (at index 0) should never be removed. Don't even show it as an option.
+                        visible: index != 0
                     }
                 }
             }

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -108,6 +108,9 @@ Pane {
                         validator: NameValidator {
                             model: components
                             myindex: index
+                            onValidationFailed: {
+                                nameField.ToolTip.show("Component names must be unique", 3000)
+                            }
                         }
                     }
 

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
+import MyValidators 1.0
 
 Pane {
 
@@ -104,6 +105,10 @@ Pane {
                         id: nameField
                         labelText: "Name:"
                         editorText: name
+                        validator: NameValidator {
+                            model: components
+                            myindex: index
+                        }
                     }
 
                     TransformControls {

--- a/resources/Qt models/GeometryControls.qml
+++ b/resources/Qt models/GeometryControls.qml
@@ -89,6 +89,7 @@ Pane {
                     labelText: "height:"
                     editorText: cylinder_height
                     onEditingFinished: cylinder_height = parseFloat(editorText)
+                    validator: numberValidator
                 }
                 LabeledTextField {
                     id: radiusField
@@ -97,6 +98,7 @@ Pane {
                     labelText: "radius:"
                     editorText: cylinder_radius
                     onEditingFinished: cylinder_radius = parseFloat(editorText)
+                    validator: numberValidator
                 }
 
                 Label {
@@ -113,6 +115,7 @@ Pane {
                     labelText: "x:"
                     editorText: axis_x
                     onEditingFinished: axis_x = parseFloat(editorText)
+                    validator: numberValidator
                 }
                 LabeledTextField {
                     id: axisYField
@@ -121,6 +124,7 @@ Pane {
                     labelText: "y:"
                     editorText: axis_y
                     onEditingFinished: axis_y = parseFloat(editorText)
+                    validator: numberValidator
                 }
                 LabeledTextField {
                     id: axisZField
@@ -129,9 +133,15 @@ Pane {
                     labelText: "z:"
                     editorText: axis_z
                     onEditingFinished: axis_z = parseFloat(editorText)
+                    validator: numberValidator
                 }
             }
         }
+    }
+
+    DoubleValidator {
+        id: numberValidator
+        notation: DoubleValidator.StandardNotation
     }
 
 

--- a/resources/Qt models/LabeledTextField.qml
+++ b/resources/Qt models/LabeledTextField.qml
@@ -6,6 +6,7 @@ Pane {
     property string labelText: ""
     property string editorText: ""
     property real editorWidth: 100
+    property var validator: null
     id: pane
     padding: 2
     contentHeight: Math.max(label.height, field.height)
@@ -24,6 +25,7 @@ Pane {
         anchors.top: parent.top
         anchors.left: label.right
         width: editorWidth
+        validator: pane.validator
 
         text: editorText
         onEditingFinished: {

--- a/resources/Qt models/PaddedButton.qml
+++ b/resources/Qt models/PaddedButton.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.4
 
 Pane {
     property string text: ""
+    property bool buttonEnabled: true
     id: pane
     padding: 2
     signal clicked
@@ -12,6 +13,7 @@ Pane {
         id: button
         anchors.fill: parent
         text: pane.text
+        enabled: buttonEnabled
         onClicked: pane.clicked()
     }
 }

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -85,6 +85,7 @@ Item {
         anchors.left: parent.left
         labelText: "x:"
         editorText: rotate_x
+        validator: numberValidator
     }
     LabeledTextField {
         id: yRotField
@@ -92,6 +93,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         labelText: "y:"
         editorText: rotate_y
+        validator: numberValidator
     }
     LabeledTextField {
         id: zRotField
@@ -99,6 +101,7 @@ Item {
         anchors.right: parent.right
         labelText: "z:"
         editorText: rotate_z
+        validator: numberValidator
     }
 
     LabeledTextField {
@@ -107,6 +110,7 @@ Item {
         anchors.right: zRotField.right
         labelText: "angle (degrees):"
         editorText: rotate_angle
+        validator: angleValidator
     }
 
     Label {
@@ -122,6 +126,7 @@ Item {
         anchors.left: parent.left
         labelText: "x:"
         editorText: translate_x
+        validator: numberValidator
     }
     LabeledTextField {
         id: yField
@@ -129,6 +134,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         labelText: "y:"
         editorText: translate_y
+        validator: numberValidator
     }
     LabeledTextField {
         id: zField
@@ -136,6 +142,19 @@ Item {
         anchors.right: parent.right
         labelText: "z:"
         editorText: translate_z
+        validator: numberValidator
+    }
+
+    DoubleValidator {
+        id: numberValidator
+        notation: DoubleValidator.StandardNotation
+    }
+
+    DoubleValidator {
+        id: angleValidator
+        top: 360
+        bottom: -360
+        notation: DoubleValidator.StandardNotation
     }
 
     ParentValidator {

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -161,5 +161,8 @@ Item {
         id: parentValidator
         model: components
         myindex: index
+        onValidationFailed: {
+            relativePicker.ToolTip.show("Items cannot be selected if they would cause a circular dependency", 5000)
+        }
     }
 }

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -1,11 +1,13 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
+import MyValidators 1.0
 
 /*
  * Controls for defining a components transformation to detector space.
  * Should be used in an environment where the following variables exist:
  * - components (InstrumentModel)
  * - transform_parent_index (integer)
+ * - index  (integer)
  * - rotate_x   (float)
  * - rotate_y   (float)
  * - rotate_z   (float)
@@ -62,6 +64,12 @@ Item {
         model: components
         textRole: "name"
         currentIndex: transform_parent_index
+        validator: parentValidator
+        onActivated: {
+            if(!acceptableInput){
+                currentIndex = transform_parent_index
+            }
+        }
     }
 
     Label {
@@ -128,5 +136,11 @@ Item {
         anchors.right: parent.right
         labelText: "z:"
         editorText: translate_z
+    }
+
+    ParentValidator {
+        id: parentValidator
+        model: components
+        myindex: index
     }
 }

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -33,3 +33,17 @@ def test_replace_contents():
     assert model.rowCount() == 2
     assert model.components == replacement_data
     assert len(model.meshes) == 2
+
+
+def test_generate_component_name():
+    model = InstrumentModel()
+    model.components = [
+        data_model.Component(name='Sample'),
+        data_model.Component(name='Detector'),
+        data_model.Component(name='Detector3'),
+        data_model.Component(name='Magnet2'),
+    ]
+    assert model.generate_component_name('Sample') == 'Sample1'
+    assert model.generate_component_name('Detector') == 'Detector4'
+    assert model.generate_component_name('Magnet') == 'Magnet'
+    assert model.generate_component_name('BeamGuide') == 'BeamGuide'

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -22,6 +22,10 @@ def test_remove_component():
     model.remove_component(1)
     assert model.rowCount() == 1
     assert not isinstance(model.components[0], data_model.Detector)
+    # The sample at index 0 shouldn't be removable
+    model.remove_component(0)
+    assert model.rowCount() == 1
+    assert isinstance(model.components[0], data_model.Sample)
 
 
 def test_replace_contents():
@@ -47,3 +51,17 @@ def test_generate_component_name():
     assert model.generate_component_name('Detector') == 'Detector4'
     assert model.generate_component_name('Magnet') == 'Magnet'
     assert model.generate_component_name('BeamGuide') == 'BeamGuide'
+
+
+def test_is_removable():
+    model = InstrumentModel()
+    model.components = [data_model.Component(name=str(i)) for i in range(4)]
+    model.components[0].transform_parent = model.components[0]
+    model.components[1].transform_parent = model.components[0]
+    model.components[2].transform_parent = model.components[1]
+    model.components[3].transform_parent = model.components[3]
+
+    assert not model.is_removable(0)
+    assert not model.is_removable(1)
+    assert model.is_removable(2)
+    assert model.is_removable(3)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,161 @@
+"""Tests for custom validators in the geometry_constructor.validators module"""
+from geometry_constructor.validators import NameValidator, TransformParentValidator
+from geometry_constructor.instrument_model import InstrumentModel
+from geometry_constructor.data_model import Component
+from PySide2.QtGui import QValidator
+
+
+def assess_component_tree(count: int, parent_mappings: dict, results: dict):
+    """
+    Test the validity of a transform parent network of components
+
+    Builds an InstrumentModel with components connected according to parent_mappings, then for each provided result,
+    checks a components validity if it were to be set to its current parent.
+    :param count: the number of components to create
+    :param parent_mappings: a dictionary of int -> int representing child and parent index numbers
+    :param results: a dictionary of int -> boolean representing the index of components to check validity for, and
+    their expected validity
+    """
+    components = [Component(name=str(i)) for i in range(count)]
+    for child, parent in parent_mappings.items():
+        components[child].transform_parent = components[parent]
+
+    model = InstrumentModel()
+    model.components = components
+
+    validator = TransformParentValidator()
+    validator.instrument_model = model
+
+    for index, expected_result in results.items():
+        validator.model_index = index
+        parent_name = components[index].transform_parent.name
+        assert (validator.validate(parent_name, 0) == QValidator.Acceptable) == expected_result
+
+
+def test_parent_validator_self_loop_terminated_tree():
+    """A parent tree where the root item points to itself is valid"""
+    parent_mappings = {
+        0: 0,
+        1: 0,
+        2: 1,
+        3: 1,
+        4: 0,
+    }
+    results = {
+        0: True,
+        1: True,
+        2: True,
+        3: True,
+        4: True,
+    }
+    assess_component_tree(5, parent_mappings, results)
+
+
+def test_parent_validator_none_terminated_tree():
+    """A parent tree where the root item has no parent is valid"""
+    parent_mappings = {
+        1: 0,
+        2: 1,
+        3: 1,
+        4: 0,
+    }
+    results = {
+        1: True,
+        2: True,
+        3: True,
+        4: True,
+    }
+    assess_component_tree(5, parent_mappings, results)
+
+
+def test_parent_validator_2_item_loop():
+    """A loop between two items is invalid, as would be any item with its parent in that loop"""
+    parent_mappings = {
+        0: 1,
+        1: 0,
+        2: 1,
+    }
+    results = {
+        0: False,
+        1: False,
+        2: False,
+    }
+    assess_component_tree(3, parent_mappings, results)
+
+
+def test_parent_validator_3_item_loop():
+    """A loop between three items is invalid, and items with parents in that loop should be too"""
+    parent_mappings = {
+        0: 1,
+        1: 2,
+        2: 0,
+        3: 2,
+    }
+    results = {
+        0: False,
+        1: False,
+        2: False,
+        3: False,
+    }
+    assess_component_tree(4, parent_mappings, results)
+
+
+def test_parent_validator_chain_beside_loop():
+    """Even if there's a loop, items disconnected from it would still be valid"""
+    parent_mappings = {
+        0: 1,
+        1: 0,
+        2: 2,
+        3: 2,
+    }
+    results = {
+        0: False,
+        1: False,
+        2: True,
+        3: True,
+    }
+    assess_component_tree(4, parent_mappings, results)
+
+
+def assess_component_names(names: list, index, new_name, expected_validity):
+    """
+    Tests the validity of a given name at a given index in an InstrumentModel with an existing list of named components
+
+    :param names: The names to give to components in the model before validating a change
+    :param index: The index to change/insert the new name at in the model
+    :param new_name: The name to check the validity of a change/insert into the model
+    :param expected_validity: Whether the name change/insert is expected to be valid
+    """
+    model = InstrumentModel()
+    model.components = [Component(name=name) for name in names]
+
+    validator = NameValidator()
+    validator.instrument_model = model
+    validator.model_index = index
+
+    assert (validator.validate(new_name, 0) == QValidator.Acceptable) == expected_validity
+
+
+def test_name_validator_new_unique_name():
+    """A name that's not already in the model, being added at a new index should be valid"""
+    assess_component_names(['foo', 'bar', 'baz'], 3, 'asdf', True)
+
+
+def test_name_validator_new_existing_name():
+    """A name that is already in the model is not valid at a new index"""
+    assess_component_names(['foo', 'bar', 'baz'], 3, 'foo', False)
+
+
+def test_name_validator_set_to_new_name():
+    """A name that's not in the model should be valid at an existing index"""
+    assess_component_names(['foo', 'bar', 'baz'], 1, 'asdf', True)
+
+
+def test_name_validator_set_to_current_name():
+    """A name should be valid at an index where it's already present"""
+    assess_component_names(['foo', 'bar', 'baz'], 1, 'bar', True)
+
+
+def test_name_validator_set_to_duplicate_name():
+    """A name that's already at an index should not be valid at another index"""
+    assess_component_names(['foo', 'bar', 'baz'], 1, 'foo', False)


### PR DESCRIPTION
Closes #43 

- Adds validators to all the numeric input fields
- Adds custom validators to ensure unique component names and to prevent dependency loops in transform parents
  - Displays tool tips when custom validators fail
- Prevents removing components that are transform parents to other components

![image](https://user-images.githubusercontent.com/2938284/48423020-b898e900-e757-11e8-92aa-ceadc9ea8245.png)

As the behaviour of text boxes with the built in validators seems to be to prevent invalid input, I've added similar code for the parent drop down. If an invalid option is clicked, it will go back to the previous selection.