### PR TITLE
Full component editor

### DIFF
--- a/geometry_constructor/application.py
+++ b/geometry_constructor/application.py
@@ -6,7 +6,7 @@ Loading this module also registers with QML the required custom classes to load 
 
 import sys
 from os import path
-from geometry_constructor.instrument_model import InstrumentModel
+from geometry_constructor.instrument_model import InstrumentModel, SingleComponentModel
 from geometry_constructor.geometry_models import CylinderModel, OFFModel
 from geometry_constructor.json_loader import JsonLoader
 from geometry_constructor.json_writer import JsonWriter
@@ -21,6 +21,7 @@ from PySide2.QtQml import QQmlApplicationEngine, qmlRegisterType
 qmlRegisterType(Logger, 'MyWriters', 1, 0, 'Logger')
 qmlRegisterType(HdfWriter, 'MyWriters', 1, 0, 'HdfWriter')
 qmlRegisterType(InstrumentModel, 'MyModels', 1, 0, 'InstrumentModel')
+qmlRegisterType(SingleComponentModel, 'MyModels', 1, 0, 'SingleComponentModel')
 qmlRegisterType(CylinderModel, 'MyModels', 1, 0, 'CylinderModel')
 qmlRegisterType(OFFModel, 'MyModels', 1, 0, 'OFFModel')
 qmlRegisterType(FilteredJsonModel, 'MyModels', 1, 0, 'FilteredJsonModel')

--- a/geometry_constructor/application.py
+++ b/geometry_constructor/application.py
@@ -10,8 +10,9 @@ from geometry_constructor.instrument_model import InstrumentModel
 from geometry_constructor.geometry_models import CylinderModel, OFFModel
 from geometry_constructor.json_loader import JsonLoader
 from geometry_constructor.json_writer import JsonWriter
+from geometry_constructor.pixel_models import PixelGridModel, PixelMappingModel
 from geometry_constructor.qml_json_model import FilteredJsonModel
-from geometry_constructor.validators import NameValidator, TransformParentValidator
+from geometry_constructor.validators import NameValidator, TransformParentValidator, NullableIntValidator
 from geometry_constructor.writers import HdfWriter, Logger
 from PySide2.QtCore import QUrl, QObject
 from PySide2.QtQml import QQmlApplicationEngine, qmlRegisterType
@@ -23,9 +24,12 @@ qmlRegisterType(InstrumentModel, 'MyModels', 1, 0, 'InstrumentModel')
 qmlRegisterType(CylinderModel, 'MyModels', 1, 0, 'CylinderModel')
 qmlRegisterType(OFFModel, 'MyModels', 1, 0, 'OFFModel')
 qmlRegisterType(FilteredJsonModel, 'MyModels', 1, 0, 'FilteredJsonModel')
+qmlRegisterType(PixelGridModel, 'MyModels', 1, 0, 'PixelGridModel')
+qmlRegisterType(PixelMappingModel, 'MyModels', 1, 0, 'PixelMappingModel')
 qmlRegisterType(JsonLoader, 'MyJson', 1, 0, 'JsonLoader')
 qmlRegisterType(JsonWriter, 'MyJson', 1, 0, 'JsonWriter')
 qmlRegisterType(NameValidator, 'MyValidators', 1, 0, 'NameValidator')
+qmlRegisterType(NullableIntValidator, 'MyValidators', 1, 0, 'NullableIntValidator')
 qmlRegisterType(TransformParentValidator, 'MyValidators', 1, 0, 'ParentValidator')
 
 

--- a/geometry_constructor/geometry_loader.py
+++ b/geometry_constructor/geometry_loader.py
@@ -3,55 +3,63 @@ from nexusutils.readwriteoff import parse_off_file
 from stl import mesh
 
 
-def load_geometry(filename: str):
+def load_geometry(filename: str, geometry: OFFGeometry=OFFGeometry()):
     """
     Loads geometry from a file into an OFFGeometry instance
 
     Supported file types are OFF and STL.
     :param filename: The name of the file to load geometry from
+    :param geometry: The optional OFFGeometry to load the geometry data into. If not provided, a new instance will be
+    returned
     :return: An OFFGeometry instance containing that file's geometry, or an empty instance if filename's extension is
     unsupported
     """
     extension = filename[filename.rfind('.'):].lower()
     if extension == '.off':
-        return load_off_geometry(filename)
+        load_off_geometry(filename, geometry)
     elif extension == '.stl':
-        return load_stl_geometry(filename)
+        load_stl_geometry(filename, geometry)
     else:
+        geometry.faces = []
+        geometry.vertices = []
         print('geometry file extension not supported')
-        return OFFGeometry()
+    return geometry
 
 
-def load_off_geometry(filename: str):
+def load_off_geometry(filename: str, geometry: OFFGeometry=OFFGeometry()):
     """
     Loads geometry from an OFF file into an OFFGeometry instance
 
     :param filename: The name of the OFF file to load geometry from
+    :param geometry: The optional OFFGeometry to load the OFF data into. If not provided, a new instance will be
+    returned
     :return: An OFFGeometry instance containing that file's geometry
     """
     with open(filename) as file:
         vertices, faces = parse_off_file(file)
 
-    vertices = [Vector(x, y, z) for x, y, z in (vertex for vertex in vertices)]
-    faces = [face.tolist()[1:] for face in faces]
+    geometry.vertices = [Vector(x, y, z) for x, y, z in (vertex for vertex in vertices)]
+    geometry.faces = [face.tolist()[1:] for face in faces]
     print('OFF loaded')
-    return OFFGeometry(vertices=vertices, faces=faces)
+    return geometry
 
 
-def load_stl_geometry(filename: str):
+def load_stl_geometry(filename: str, geometry: OFFGeometry=OFFGeometry()):
     """
     Loads geometry from an STL file into an OFFGeometry instance
 
     :param filename: The name of the STL file to load geometry from
+    :param geometry: The optional OFFGeometry to load the STL data into. If not provided, a new instance will be
+    returned
     :return: An OFFGeometry instance containing that file's geometry
     """
     mesh_data = mesh.Mesh.from_file(filename, calculate_normals=False)
     # numpy-stl loads numbers as python decimals, not floats, which aren't valid in json
-    vertices = [Vector(float(corner[0]),
-                       float(corner[1]),
-                       float(corner[2]))
-                for triangle in mesh_data.vectors
-                for corner in triangle]
-    faces = [[i * 3, (i * 3) + 1, (i * 3) + 2] for i in range(len(mesh_data.vectors))]
+    geometry.vertices = [Vector(float(corner[0]),
+                                float(corner[1]),
+                                float(corner[2]))
+                         for triangle in mesh_data.vectors
+                         for corner in triangle]
+    geometry.faces = [[i * 3, (i * 3) + 1, (i * 3) + 2] for i in range(len(mesh_data.vectors))]
     print('STL loaded')
-    return OFFGeometry(vertices=vertices, faces=faces)
+    return geometry

--- a/geometry_constructor/geometry_models.py
+++ b/geometry_constructor/geometry_models.py
@@ -152,10 +152,9 @@ class OFFModel(QAbstractListModel):
             filename = self.file_url.toString(options=QUrl.PreferLocalFile)
         else:
             filename = self.file_url
+        self.beginResetModel()
         self.geometry = load_geometry(filename)
-        index = self.createIndex(0, 0)
-        self.dataChanged.emit(index, index, [OFFModel.VerticesRole,
-                                             OFFModel.FacesRole])
+        self.endResetModel()
 
     def get_geometry(self):
         return self.geometry

--- a/geometry_constructor/geometry_models.py
+++ b/geometry_constructor/geometry_models.py
@@ -153,7 +153,7 @@ class OFFModel(QAbstractListModel):
         else:
             filename = self.file_url
         self.beginResetModel()
-        self.geometry = load_geometry(filename)
+        load_geometry(filename, self.geometry)
         self.endResetModel()
 
     def get_geometry(self):

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -75,7 +75,6 @@ class InstrumentModel(QAbstractListModel):
                            [1, 7, 5, 3],
                            [6, 0, 2, 4]]
                 ))]
-        self.meshes = [self.generate_mesh(component) for component in self.components]
 
     def rowCount(self, parent=QModelIndex()):
         return len(self.components)
@@ -100,7 +99,7 @@ class InstrumentModel(QAbstractListModel):
                 else 0,
             InstrumentModel.PixelStateRole: lambda: self.determine_pixel_state(component),
             InstrumentModel.GeometryStateRole: lambda: self.determine_geometry_state(component),
-            InstrumentModel.MeshRole: lambda: self.meshes[row],
+            InstrumentModel.MeshRole: lambda: self.generate_mesh(component),
             InstrumentModel.TransformMatrixRole: lambda: self.generate_matrix(component),
             InstrumentModel.RemovableRole: lambda: self.is_removable(row),
         }
@@ -188,7 +187,6 @@ class InstrumentModel(QAbstractListModel):
                             geometry=geometry,
                             pixel_data=pixels)
         self.components.append(detector)
-        self.meshes.append(self.generate_mesh(detector))
         self.endInsertRows()
         self.update_removable()
 
@@ -197,7 +195,6 @@ class InstrumentModel(QAbstractListModel):
         if self.is_removable(index):
             self.beginRemoveRows(QModelIndex(), index, index)
             self.components.pop(index)
-            self.meshes.pop(index)
             self.endRemoveRows()
             self.update_removable()
 
@@ -205,7 +202,6 @@ class InstrumentModel(QAbstractListModel):
     def set_geometry(self, index, geometry_model):
         print(geometry_model)
         self.components[index].geometry = geometry_model.get_geometry()
-        self.meshes[index] = self.generate_mesh(self.components[index])
         model_index = self.createIndex(index, 0)
         self.dataChanged.emit(model_index, model_index, [InstrumentModel.GeometryStateRole,
                                                          InstrumentModel.MeshRole])
@@ -216,7 +212,6 @@ class InstrumentModel(QAbstractListModel):
     def replace_contents(self, components):
         self.beginResetModel()
         self.components = components
-        self.meshes = [self.generate_mesh(component) for component in self.components]
         self.endResetModel()
 
     def generate_mesh(self, component: Component):
@@ -312,7 +307,6 @@ class InstrumentModel(QAbstractListModel):
         :param index: The index in this model of the component needing it's mesh updated
         """
         component = self.components[index]
-        self.meshes[index] = self.generate_mesh(component)
 
         model_index = self.createIndex(index, 0)
         self.dataChanged.emit(model_index, model_index, InstrumentModel.MeshRole)

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -306,8 +306,6 @@ class InstrumentModel(QAbstractListModel):
 
         :param index: The index in this model of the component needing it's mesh updated
         """
-        component = self.components[index]
-
         model_index = self.createIndex(index, 0)
         self.dataChanged.emit(model_index, model_index, InstrumentModel.MeshRole)
 

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -130,20 +130,20 @@ class InstrumentModel(QAbstractListModel):
         }
         if role in param_options:
             param_list = param_options[role]()
-            changed = self.change_value(*param_list)
+            changed = self.change_value(item, *param_list)
         if changed:
             self.dataChanged.emit(index, index, role)
             if role == InstrumentModel.TransformParentIndexRole:
                 self.update_removable()
         return changed
 
-    def change_value(self, item, attribute_name, value, transforms):
+    def change_value(self, component, item, attribute_name, value, transforms):
         current_value = getattr(item, attribute_name)
         different = value != current_value
         if different:
             setattr(item, attribute_name, value)
             if transforms:
-                self.update_child_transforms(item)
+                self.update_child_transforms(component)
         return different
 
     def flags(self, index):

--- a/geometry_constructor/instrument_model.py
+++ b/geometry_constructor/instrument_model.py
@@ -169,13 +169,15 @@ class InstrumentModel(QAbstractListModel):
         }
 
     @Slot(str)
-    @Slot(str, str, int, float, float, float, float, float, float, float, 'QVariant')
+    @Slot(str, str, int, float, float, float, float, float, float, float, 'QVariant', 'QVariant')
     def add_detector(self, name, description='', parent_index=0,
                      translate_x=0, translate_y=0, translate_z=0,
                      rotate_x=0, rotate_y=0, rotate_z=1, rotate_angle=0,
-                     geometry_model=None):
+                     geometry_model=None,
+                     pixel_model=None):
         self.beginInsertRows(QModelIndex(), self.rowCount(), self.rowCount())
         geometry = None if geometry_model is None else geometry_model.get_geometry()
+        pixels = None if pixel_model is None else pixel_model.get_pixel_model()
         detector = Detector(name=name,
                             description=description,
                             transform_parent=self.components[parent_index],
@@ -183,9 +185,7 @@ class InstrumentModel(QAbstractListModel):
                             rotate_axis=Vector(rotate_x, rotate_y, rotate_z),
                             rotate_angle=rotate_angle,
                             geometry=geometry,
-                            pixel_data=PixelGrid(rows=3, columns=4, row_height=2, col_width=3,
-                                                 first_id=0, count_direction=CountDirection.ROW,
-                                                 initial_count_corner=Corner.TOP_LEFT))
+                            pixel_data=pixels)
         self.components.append(detector)
         self.meshes.append(self.generate_mesh(detector))
         self.endInsertRows()

--- a/geometry_constructor/pixel_models.py
+++ b/geometry_constructor/pixel_models.py
@@ -1,0 +1,144 @@
+"""
+ListModel implementations for accessing and manipulating detector pixel data in QML
+
+See http://doc.qt.io/qt-5/qabstractlistmodel.html#subclassing for guidance on how to develop these classes, including
+what signals need to be emitted when changes to the data are made.
+"""
+from geometry_constructor.geometry_models import change_value, OFFModel
+from geometry_constructor.data_model import PixelMapping, PixelGrid, Detector, Corner, CountDirection
+from geometry_constructor.instrument_model import InstrumentModel
+from PySide2.QtCore import Qt, QAbstractListModel, QModelIndex, Slot
+from math import isnan
+
+
+class PixelGridModel(QAbstractListModel):
+    """
+    A single item list model that allows properties of a PixelGrid to be read and manipulated in QML
+    """
+
+    RowsRole = Qt.UserRole + 400
+    ColumnsRole = Qt.UserRole + 401
+    RowHeightRole = Qt.UserRole + 402
+    ColumnWidthRole = Qt.UserRole + 403
+    FirstIdRole = Qt.UserRole + 404
+    CountDirectionRole = Qt.UserRole + 405
+    InitialCountCornerRole = Qt.UserRole + 406
+
+    def __init__(self):
+        super().__init__()
+        self.pixel_grid = PixelGrid()
+
+    def rowCount(self, parent=QModelIndex()):
+        return 1
+
+    def data(self, index, role=Qt.DisplayRole):
+        properties = {
+            PixelGridModel.RowsRole: self.pixel_grid.rows,
+            PixelGridModel.ColumnsRole: self.pixel_grid.columns,
+            PixelGridModel.RowHeightRole: self.pixel_grid.row_height,
+            PixelGridModel.ColumnWidthRole: self.pixel_grid.col_width,
+            PixelGridModel.FirstIdRole: self.pixel_grid.first_id,
+            PixelGridModel.CountDirectionRole: self.pixel_grid.count_direction,
+            PixelGridModel.InitialCountCornerRole: self.pixel_grid.initial_count_corner,
+        }
+        if role in properties:
+            return properties[role]
+
+    def setData(self, index, value, role):
+        changed = False
+        # lambda wrappings prevent casting errors when setting other types
+        param_options = {
+            PixelGridModel.RowsRole: lambda: [self.pixel_grid, 'rows', int(value)],
+            PixelGridModel.ColumnsRole: lambda: [self.pixel_grid, 'columns', int(value)],
+            PixelGridModel.RowHeightRole: lambda: [self.pixel_grid, 'row_height', value],
+            PixelGridModel.ColumnWidthRole: lambda: [self.pixel_grid, 'col_width', value],
+            PixelGridModel.FirstIdRole: lambda: [self.pixel_grid, 'first_id', int(value)],
+            PixelGridModel.CountDirectionRole: lambda: [self.pixel_grid, 'count_direction', CountDirection[value]],
+            PixelGridModel.InitialCountCornerRole: lambda: [self.pixel_grid, 'initial_count_corner', Corner[value]],
+        }
+        if role in param_options:
+            param_list = param_options[role]()
+            changed = change_value(*param_list)
+        if changed:
+            self.dataChanged.emit(index, index, role)
+        return changed
+
+    def flags(self, index):
+        return super().flags(index) | Qt.ItemIsEditable
+
+    def roleNames(self):
+        return {
+            PixelGridModel.RowsRole: b'rows',
+            PixelGridModel.ColumnsRole: b'columns',
+            PixelGridModel.RowHeightRole: b'row_height',
+            PixelGridModel.ColumnWidthRole: b'col_width',
+            PixelGridModel.FirstIdRole: b'first_id',
+            PixelGridModel.CountDirectionRole: b'count_direction',
+            PixelGridModel.InitialCountCornerRole: b'initial_count_corner',
+        }
+
+    def get_pixel_model(self):
+        return self.pixel_grid
+
+    @Slot(int, 'QVariant')
+    def set_pixel_model(self, index, instrument: InstrumentModel):
+        component = instrument.components[index]
+        if isinstance(component, Detector) and isinstance(component.pixel_data, PixelGrid):
+            self.beginResetModel()
+            self.pixel_grid = component.pixel_data
+            self.endResetModel()
+
+
+class PixelMappingModel(QAbstractListModel):
+    """A list model that allows for accessing and changing a PixelMappings face id to pixel id mappings in QML"""
+
+    PixelIdRole = Qt.UserRole + 500
+
+    def __init__(self):
+        super().__init__()
+        self.pixel_mapping = PixelMapping(pixel_ids=[])
+
+    def rowCount(self, parent=QModelIndex()):
+        return len(self.pixel_mapping.pixel_ids)
+
+    def data(self, index, role=Qt.DisplayRole):
+        if role == PixelMappingModel.PixelIdRole:
+            row = index.row()
+            return self.pixel_mapping.pixel_ids[row]
+
+    def setData(self, index, value, role):
+        changed = False
+        if role == PixelMappingModel.PixelIdRole:
+            row = index.row()
+            current_value = self.pixel_mapping.pixel_ids[row]
+            if current_value != value:
+                self.pixel_mapping.pixel_ids[row] = None if isnan(value) else value
+                self.dataChanged.emit(index, index, role)
+                changed = True
+        return changed
+
+    def flags(self, index):
+        return super().flags(index) | Qt.ItemIsEditable
+
+    def roleNames(self):
+        return {
+            PixelMappingModel.PixelIdRole: b'pixel_id',
+        }
+
+    def get_pixel_model(self):
+        return self.pixel_mapping
+
+    @Slot(int, 'QVariant')
+    def set_pixel_model(self, index, instrument: InstrumentModel):
+        component = instrument.components[index]
+        if isinstance(component, Detector) and isinstance(component.pixel_data, PixelMapping):
+            self.beginResetModel()
+            self.pixel_mapping = component.pixel_data
+            self.endResetModel()
+
+    @Slot('QVariant')
+    def restart_mapping(self, geometry_model):
+        if isinstance(geometry_model, OFFModel):
+            self.beginResetModel()
+            self.pixel_mapping.pixel_ids = [None for _ in range(len(geometry_model.geometry.faces))]
+            self.endResetModel()

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -1,7 +1,15 @@
 """Validators to be used on QML input fields"""
 from geometry_constructor.instrument_model import InstrumentModel
 from PySide2.QtCore import Property, Signal
-from PySide2.QtGui import QValidator
+from PySide2.QtGui import QValidator, QIntValidator
+
+
+class NullableIntValidator(QIntValidator):
+    def validate(self, input: str, pos: int):
+        if input == '':
+            return QValidator.Acceptable
+        else:
+            return super().validate(input, pos)
 
 
 class ValidatorOnInstrumentModel(QValidator):

--- a/geometry_constructor/validators.py
+++ b/geometry_constructor/validators.py
@@ -27,7 +27,7 @@ class ValidatorOnInstrumentModel(QValidator):
     def __init__(self):
         super().__init__()
         self.instrument_model = InstrumentModel()
-        self.model_index = -1
+        self.model_index = 0
 
     def get_index(self):
         return self.model_index

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -37,8 +37,8 @@ Window {
 
         Pane {
             id: geometrySelectionPane
-            contentWidth: Math.max(geometryLabel.width, offButton.width, cylinderButton.width)
-            contentHeight: geometryLabel.height + offButton.height + cylinderButton.height
+            contentWidth: Math.max(geometryLabel.width, offButton.width, cylinderButton.width, mappedMeshButton.width)
+            contentHeight: geometryLabel.height + offButton.height + cylinderButton.height + mappedMeshButton.height
             visible: true
 
             Label {
@@ -52,6 +52,7 @@ Window {
                 text: "Repeatable Mesh"
                 onClicked: {
                     geometryControls.state = "OFF"
+                    pixelControls.state = "Grid"
                     name = components.generate_component_name("Detector")
                     contentPane.state = "EnterDetails"
                 }
@@ -63,6 +64,19 @@ Window {
                 text: "Repeatable Cylinder"
                 onClicked: {
                     geometryControls.state = "Cylinder"
+                    pixelControls.state = "Grid"
+                    name = components.generate_component_name("Detector")
+                    contentPane.state = "EnterDetails"
+                }
+            }
+
+            PaddedButton {
+                id: mappedMeshButton
+                anchors.top: cylinderButton.bottom
+                text: "Pixel-Face Mapped Mesh"
+                onClicked: {
+                    geometryControls.state = "OFF"
+                    pixelControls.state = "Mapping"
                     name = components.generate_component_name("Detector")
                     contentPane.state = "EnterDetails"
                 }
@@ -77,6 +91,7 @@ Window {
                            + transformLabel.height
                            + transformFrame.height
                            + geometryControls.height
+                           + pixelControls.height
                            + addButton.height
             visible: false
 
@@ -107,7 +122,7 @@ Window {
                 id: transformLabel
                 anchors.top: descriptionField.bottom
                 anchors.left: parent.left
-                text: "Transform"
+                text: "Transform:"
             }
 
             Frame {
@@ -123,19 +138,30 @@ Window {
             GeometryControls {
                 id: geometryControls
                 anchors.top: transformFrame.bottom
+                onMeshChanged: pixelControls.restartMapping(geometryControls.geometryModel)
+            }
+
+            PixelControls {
+                id: pixelControls
+                anchors.top: geometryControls.bottom
+                anchors.right:parent.right
+                anchors.left: parent.left
+                width: parent.contentWidth
             }
 
             PaddedButton {
                 id: addButton
-                anchors.top: geometryControls.bottom
+                anchors.top: pixelControls.bottom
                 anchors.left: parent.left
+                leftPadding: 0
                 text: "Add"
                 onClicked: {
                     transformControls.saveFields()
                     components.add_detector(name, description, transform_parent_index,
                                             translate_x, translate_y, translate_z,
                                             rotate_x, rotate_y, rotate_z, rotate_angle,
-                                            geometryControls.geometryModel)
+                                            geometryControls.geometryModel,
+                                            pixelControls.pixelModel)
                     addDetectorWindow.close()
                 }
             }

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -156,7 +156,6 @@ Window {
                 leftPadding: 0
                 text: "Add"
                 onClicked: {
-                    transformControls.saveFields()
                     components.add_detector(name, description, transform_parent_index,
                                             translate_x, translate_y, translate_z,
                                             rotate_x, rotate_y, rotate_z, rotate_angle,

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -21,7 +21,6 @@ Window {
 
     title: "Add Detector"
     id: addDetectorWindow
-    modality: Qt.ApplicationModal
     minimumHeight: contentPane.height
     minimumWidth: contentPane.width
     height: minimumHeight

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -85,7 +85,7 @@ Window {
 
         Pane {
             id: detailsPane
-            contentWidth: transformFrame.width
+            contentWidth:  Math.max(transformFrame.implicitWidth, geometryControls.implicitWidth, pixelControls.implicitWidth)
             contentHeight: nameField.height
                            + descriptionField.height
                            + transformLabel.height
@@ -131,9 +131,13 @@ Window {
                 id: transformFrame
                 anchors.top: transformLabel.bottom
                 contentHeight: transformControls.height
-                contentWidth: transformControls.width
+                contentWidth: transformControls.implicitWidth
+                anchors.left: parent.left
+                anchors.right: parent.right
                 TransformControls {
                     id: transformControls
+                    anchors.left: parent.left
+                    anchors.right: parent.right
                 }
             }
 

--- a/resources/Qt models/AddDetectorWindow.qml
+++ b/resources/Qt models/AddDetectorWindow.qml
@@ -85,7 +85,7 @@ Window {
 
         Pane {
             id: detailsPane
-            contentWidth: Math.max(transformFrame.width, geometryControls.width)
+            contentWidth: transformFrame.width
             contentHeight: nameField.height
                            + descriptionField.height
                            + transformLabel.height
@@ -112,7 +112,9 @@ Window {
             LabeledTextField {
                 id: descriptionField
                 anchors.left: parent.left
+                anchors.right: parent.right
                 anchors.top: nameField.bottom
+                anchoredEditor: true
                 labelText: "Description:"
                 editorText: description
                 onEditingFinished: description = editorText
@@ -138,6 +140,8 @@ Window {
             GeometryControls {
                 id: geometryControls
                 anchors.top: transformFrame.bottom
+                anchors.right:parent.right
+                anchors.left: parent.left
                 onMeshChanged: pixelControls.restartMapping(geometryControls.geometryModel)
             }
 
@@ -146,7 +150,6 @@ Window {
                 anchors.top: geometryControls.bottom
                 anchors.right:parent.right
                 anchors.left: parent.left
-                width: parent.contentWidth
             }
 
             PaddedButton {

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -25,8 +25,12 @@ Pane {
 
             text: "Add detector"
             onClicked: {
-                modalLoader.source = "AddDetectorWindow.qml"
-                modalLoader.item.show()
+                if (modalLoader.source == ""){
+                    modalLoader.source = "AddDetectorWindow.qml"
+                    modalLoader.item.show()
+                } else {
+                    modalLoader.item.requestActivate()
+                }
             }
             Loader {
                 id: modalLoader
@@ -133,9 +137,13 @@ Pane {
                         width: parent.width / 4
                         text: "Full editor"
                         onClicked: {
-                            editorLoader.source = "EditComponentWindow.qml"
-                            editorLoader.item.componentIndex = index
-                            editorLoader.item.show()
+                            if (editorLoader.source == ""){
+                                editorLoader.source = "EditComponentWindow.qml"
+                                editorLoader.item.componentIndex = index
+                                editorLoader.item.show()
+                            } else {
+                                editorLoader.item.requestActivate()
+                            }
                         }
                     }
                     Loader {

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -41,6 +41,10 @@ Pane {
                     target: modalLoader.item
                     onClosing: modalLoader.source = ""
                 }
+                Connections {
+                    target: window
+                    onClosing: modalLoader.source = ""
+                }
             }
         }
     }
@@ -156,6 +160,10 @@ Pane {
                         id: editorLoader
                         Connections {
                             target: editorLoader.item
+                            onClosing: editorLoader.source = ""
+                        }
+                        Connections {
+                            target: window
                             onClosing: editorLoader.source = ""
                         }
                     }

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -125,6 +125,18 @@ Pane {
                         anchors.left: parent.left
                         width: parent.width / 4
                         text: "Full editor"
+                        onClicked: {
+                            editorLoader.source = "EditComponentWindow.qml"
+                            editorLoader.item.componentIndex = index
+                            editorLoader.item.show()
+                        }
+                    }
+                    Loader {
+                        id: editorLoader
+                        Connections {
+                            target: editorLoader.item
+                            onClosing: editorLoader.source = ""
+                        }
                     }
                     PaddedButton {
                         id: applyButton

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -28,8 +28,7 @@ Pane {
             onClicked: {
                 if (modalLoader.source == ""){
                     modalLoader.source = "AddDetectorWindow.qml"
-                    modalLoader.item.x = window.x + ((window.width - modalLoader.item.width) / 2)
-                    modalLoader.item.y = window.y + ((window.height - modalLoader.item.height) / 2)
+                    window.positionChildWindow(modalLoader.item)
                     modalLoader.item.show()
                 } else {
                     modalLoader.item.requestActivate()
@@ -148,8 +147,7 @@ Pane {
                             if (editorLoader.source == ""){
                                 editorLoader.source = "EditComponentWindow.qml"
                                 editorLoader.item.componentIndex = index
-                                editorLoader.item.x = window.x + ((window.width - editorLoader.item.width) / 2)
-                                editorLoader.item.y = window.y + ((window.height - editorLoader.item.height) / 2)
+                                window.positionChildWindow(editorLoader.item)
                                 editorLoader.item.show()
                             } else {
                                 editorLoader.item.requestActivate()

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -4,7 +4,8 @@ import MyValidators 1.0
 
 Pane {
 
-    contentWidth: listContainer.width
+    contentWidth: listContainer.implicitWidth
+    contentHeight: headingRow.implicitHeight + listContainer.implicitHeight
 
     Pane {
         id: headingRow
@@ -46,6 +47,7 @@ Pane {
         id: listContainer
         anchors.left: parent.left
         contentWidth: componentListView.width
+        contentHeight: 100
         anchors.top: headingRow.bottom
         anchors.bottom: parent.bottom
         padding: 1

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -28,6 +28,8 @@ Pane {
             onClicked: {
                 if (modalLoader.source == ""){
                     modalLoader.source = "AddDetectorWindow.qml"
+                    modalLoader.item.x = window.x + ((window.width - modalLoader.item.width) / 2)
+                    modalLoader.item.y = window.y + ((window.height - modalLoader.item.height) / 2)
                     modalLoader.item.show()
                 } else {
                     modalLoader.item.requestActivate()
@@ -142,6 +144,8 @@ Pane {
                             if (editorLoader.source == ""){
                                 editorLoader.source = "EditComponentWindow.qml"
                                 editorLoader.item.componentIndex = index
+                                editorLoader.item.x = window.x + ((window.width - editorLoader.item.width) / 2)
+                                editorLoader.item.y = window.y + ((window.height - editorLoader.item.height) / 2)
                                 editorLoader.item.show()
                             } else {
                                 editorLoader.item.requestActivate()

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -4,6 +4,8 @@ import MyValidators 1.0
 
 Pane {
 
+    contentWidth: listContainer.width
+
     Pane {
         id: headingRow
         anchors.left: parent.left
@@ -37,8 +39,9 @@ Pane {
     }
 
     Frame {
+        id: listContainer
         anchors.left: parent.left
-        anchors.right: parent.right
+        contentWidth: componentListView.width
         anchors.top: headingRow.bottom
         anchors.bottom: parent.bottom
         padding: 1
@@ -46,7 +49,8 @@ Pane {
             id: componentListView
             model: components
             delegate: componentDelegate
-            anchors.fill: parent
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
             clip: true
         }
     }
@@ -57,7 +61,9 @@ Pane {
             id: componentBox
             padding: 5
             contentHeight: Math.max(mainContent.height, expansionCaret.height)
-            width: componentListView.width
+            contentWidth: transformControls.width
+
+            Component.onCompleted: componentListView.width = componentBox.width
 
             MouseArea {
                 id: expansionClickArea

--- a/resources/Qt models/ComponentControls.qml
+++ b/resources/Qt models/ComponentControls.qml
@@ -105,6 +105,7 @@ Pane {
                         id: nameField
                         labelText: "Name:"
                         editorText: name
+                        onEditingFinished: name = editorText
                         validator: NameValidator {
                             model: components
                             myindex: index
@@ -139,31 +140,9 @@ Pane {
                         }
                     }
                     PaddedButton {
-                        id: applyButton
-                        anchors.top: editorButton.top
-                        anchors.left: editorButton.right
-                        width: parent.width / 4
-                        text: "Apply changes"
-                        onClicked: {
-                            name = nameField.editorText
-                            transformControls.saveFields()
-                        }
-                    }
-                    PaddedButton {
-                        id: discardButton
-                        anchors.top: editorButton.top
-                        anchors.left: applyButton.right
-                        width: parent.width / 4
-                        text: "Discard changes"
-                        onClicked: {
-                            nameField.editorText = name
-                            transformControls.resetFields()
-                        }
-                    }
-                    PaddedButton {
                         id: deleteButton
                         anchors.top: editorButton.top
-                        anchors.left: discardButton.right
+                        anchors.right: parent.right
                         width: parent.width / 4
                         text: "Delete"
                         onClicked: components.remove_component(index)

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -23,6 +23,7 @@ Window {
             height: contentHeight
             model: component
             delegate: editorDelegate
+            interactive: false
         }
     }
 

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -86,7 +86,6 @@ Window {
                 contentWidth: transformControls.width
                 TransformControls {
                     id: transformControls
-                    autosave: true
                 }
             }
 

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -49,7 +49,7 @@ Window {
                            + geometryControls.height
                            + pixelControls.height
 
-            Component.onCompleted: view.width = detailsPane.width
+            onWidthChanged: view.width = detailsPane.width
 
             LabeledTextField {
                 id: nameField
@@ -87,9 +87,13 @@ Window {
                 id: transformFrame
                 anchors.top: transformLabel.bottom
                 contentHeight: transformControls.height
-                contentWidth: transformControls.width
+                contentWidth: transformControls.implicitWidth
+                anchors.left: parent.left
+                anchors.right: parent.right
                 TransformControls {
                     id: transformControls
+                    anchors.left: parent.left
+                    anchors.right: parent.right
                 }
             }
 
@@ -113,7 +117,6 @@ Window {
                 anchors.top: geometryControls.bottom
                 anchors.right:parent.right
                 anchors.left: parent.left
-                width: parent.contentWidth
                 state: pixel_state
                 visible: pixel_state != ""
 

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -13,6 +13,10 @@ Window {
     modality: Qt.ApplicationModal
     minimumHeight: view.height
     minimumWidth: view.width
+    height: minimumHeight
+    width: minimumWidth
+    maximumHeight: minimumHeight
+    maximumWidth: minimumWidth
 
     Pane {
         id: viewContainer

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -64,7 +64,9 @@ Window {
             LabeledTextField {
                 id: descriptionField
                 anchors.left: parent.left
+                anchors.right: parent.right
                 anchors.top: nameField.bottom
+                anchoredEditor: true
                 labelText: "Description:"
                 editorText: description
                 onEditingFinished: description = editorText
@@ -91,6 +93,8 @@ Window {
             GeometryControls {
                 id: geometryControls
                 anchors.top: transformFrame.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
                 state: geometry_state
 
                 Component.onCompleted: geometryControls.geometryModel.set_geometry(componentIndex, components)

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -84,6 +84,7 @@ Window {
                 contentWidth: transformControls.width
                 TransformControls {
                     id: transformControls
+                    autosave: true
                 }
             }
 

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -1,0 +1,120 @@
+import QtQuick 2.11
+import QtQuick.Window 2.11
+import QtQuick.Controls 2.4
+import MyModels 1.0
+import MyValidators 1.0
+
+Window {
+
+    property int componentIndex: 0
+
+    title: "Component Editor"
+    id: editComponentWindow
+    modality: Qt.ApplicationModal
+    minimumHeight: view.height
+    minimumWidth: view.width
+
+    Pane {
+        id: viewContainer
+        padding: 0
+        anchors.fill: parent
+        ListView {
+            id: view
+            height: contentHeight
+            model: component
+            delegate: editorDelegate
+        }
+    }
+
+    SingleComponentModel {
+        id: component
+        model: components
+        index: componentIndex
+    }
+
+    Component {
+        id: editorDelegate
+        Pane {
+            id: detailsPane
+            contentWidth: Math.max(transformFrame.width, geometryControls.width)
+            contentHeight: nameField.height
+                           + descriptionField.height
+                           + transformLabel.height
+                           + transformFrame.height
+                           + geometryControls.height
+                           + pixelControls.height
+
+            Component.onCompleted: view.width = detailsPane.width
+
+            LabeledTextField {
+                id: nameField
+                labelText: "Name:"
+                editorText: name
+                onEditingFinished: name = editorText
+                validator: NameValidator {
+                    model: components
+                    myindex: componentIndex
+                    onValidationFailed: {
+                        nameField.ToolTip.show("Component names must be unique", 3000)
+                    }
+                }
+            }
+
+            LabeledTextField {
+                id: descriptionField
+                anchors.left: parent.left
+                anchors.top: nameField.bottom
+                labelText: "Description:"
+                editorText: description
+                onEditingFinished: description = editorText
+            }
+
+            Label {
+                id: transformLabel
+                anchors.top: descriptionField.bottom
+                anchors.left: parent.left
+                text: "Transform:"
+            }
+
+            Frame {
+                id: transformFrame
+                anchors.top: transformLabel.bottom
+                contentHeight: transformControls.height
+                contentWidth: transformControls.width
+                TransformControls {
+                    id: transformControls
+                }
+            }
+
+            GeometryControls {
+                id: geometryControls
+                anchors.top: transformFrame.bottom
+                state: geometry_state
+
+                Component.onCompleted: geometryControls.geometryModel.set_geometry(componentIndex, components)
+                onMeshChanged: {
+                    pixelControls.restartMapping(geometryControls.geometryModel)
+                    components.update_mesh(componentIndex)
+                }
+                onCylinderChanged: components.update_mesh(componentIndex)
+            }
+
+            PixelControls {
+                id: pixelControls
+                anchors.top: geometryControls.bottom
+                anchors.right:parent.right
+                anchors.left: parent.left
+                width: parent.contentWidth
+                state: pixel_state
+                visible: pixel_state != ""
+
+                Component.onCompleted:{
+                    if (pixel_state != "") {
+                        pixelControls.pixelModel.set_pixel_model(componentIndex, components)
+                    }
+                }
+                onLayoutChanged: components.update_mesh(componentIndex)
+            }
+        }
+    }
+}

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -37,7 +37,7 @@ Window {
         id: editorDelegate
         Pane {
             id: detailsPane
-            contentWidth: Math.max(transformFrame.width, geometryControls.width)
+            contentWidth: Math.max(transformFrame.implicitWidth, geometryControls.implicitWidth, pixelControls.implicitWidth)
             contentHeight: nameField.height
                            + descriptionField.height
                            + transformLabel.height

--- a/resources/Qt models/EditComponentWindow.qml
+++ b/resources/Qt models/EditComponentWindow.qml
@@ -10,7 +10,6 @@ Window {
 
     title: "Component Editor"
     id: editComponentWindow
-    modality: Qt.ApplicationModal
     minimumHeight: view.height
     minimumWidth: view.width
     height: minimumHeight

--- a/resources/Qt models/GeometryControls.qml
+++ b/resources/Qt models/GeometryControls.qml
@@ -13,6 +13,7 @@ Pane {
     contentHeight: view.height
 
     signal meshChanged()
+    signal cylinderChanged()
 
     ListView {
         id: view
@@ -27,6 +28,7 @@ Pane {
 
     CylinderModel {
         id: cylinderModel
+        onDataChanged: pane.cylinderChanged()
     }
 
     Component {

--- a/resources/Qt models/GeometryControls.qml
+++ b/resources/Qt models/GeometryControls.qml
@@ -9,7 +9,7 @@ Pane {
 
     id: pane
     padding: 0
-    contentWidth: view.width
+    contentWidth: view.implicitWidth
     contentHeight: view.height
 
     signal meshChanged()
@@ -18,7 +18,8 @@ Pane {
     ListView {
         id: view
         height: contentHeight
-        width: parent.width
+        anchors.left: parent.left
+        anchors.right: parent.right
         interactive: false
     }
 
@@ -36,8 +37,11 @@ Pane {
         id: offDelegate
         Item {
             id: offContainer
-            width: parent.width
+            width: view.width
+            implicitWidth: fileTextField.implicitWidth + chooseFileButton.width
             height: Math.max(fileTextField.height, chooseFileButton.height)
+
+            Component.onCompleted: view.implicitWidth = offContainer.implicitWidth
 
             LabeledTextField {
                 id: fileTextField
@@ -72,8 +76,11 @@ Pane {
         id: cylinderDelegate
         Item {
             id: cylinderContainer
-            width: parent.width
+            width: view.width
+            implicitWidth: fields.implicitWidth
             height: cylinderLabel.height + fields.height
+
+            Component.onCompleted: view.implicitWidth = cylinderContainer.implicitWidth
 
             Label {
                 id: cylinderLabel
@@ -85,9 +92,11 @@ Pane {
             Frame {
                 id: fields
                 anchors.top: cylinderLabel.bottom
-                contentWidth: Math.max(heightField.width + radiusField.width,
-                                       axisXField.width + axisYField.width + axisZField.width)
-                contentHeight: heightField.height + directionLabel.height + axisXField.height
+                anchors.left: parent.left
+                anchors.right: parent.right
+                contentWidth: Math.max(heightField.implicitWidth + radiusField.implicitWidth,
+                                       axisXField.implicitWidth + axisYField.implicitWidth + axisZField.implicitWidth)
+                contentHeight: heightField.implicitHeight + directionLabel.implicitHeight + axisXField.implicitHeight
 
                 LabeledTextField {
                     id: heightField

--- a/resources/Qt models/GeometryControls.qml
+++ b/resources/Qt models/GeometryControls.qml
@@ -12,6 +12,8 @@ Pane {
     contentWidth: view.width
     contentHeight: view.height
 
+    signal meshChanged()
+
     ListView {
         id: view
         height: contentHeight
@@ -20,6 +22,7 @@ Pane {
 
     OFFModel {
         id: offModel
+        onModelReset: pane.meshChanged()
     }
 
     CylinderModel {

--- a/resources/Qt models/GeometryControls.qml
+++ b/resources/Qt models/GeometryControls.qml
@@ -18,6 +18,7 @@ Pane {
     ListView {
         id: view
         height: contentHeight
+        width: parent.width
         interactive: false
     }
 
@@ -42,15 +43,16 @@ Pane {
                 id: fileTextField
                 anchors.top: parent.top
                 anchors.left: parent.left
+                anchors.right: chooseFileButton.left
                 labelText: "Geometry file:"
                 editorText: file_url
-                editorWidth: 200
+                anchoredEditor: true
                 onEditingFinished: file_url = editorText
             }
             Button {
                 id: chooseFileButton
                 anchors.verticalCenter: fileTextField.verticalCenter
-                anchors.left: fileTextField.right
+                anchors.right: parent.right
                 text: "Choose file"
                 onClicked: filePicker.open()
             }

--- a/resources/Qt models/LabeledTextField.qml
+++ b/resources/Qt models/LabeledTextField.qml
@@ -3,11 +3,11 @@ import QtQuick.Controls 2.4
 
 
 Pane {
-    property string labelText: ""
-    property string editorText: ""
+    property alias labelText: label.text
+    property alias editorText: field.text
     property alias editorWidth: field.width
+    property alias validator: field.validator
     property bool anchoredEditor: false
-    property var validator: null
     id: pane
     padding: 2
     contentHeight: Math.max(label.height, field.height)
@@ -18,7 +18,6 @@ Pane {
         id: label
         anchors.verticalCenter: field.verticalCenter
         anchors.left: parent.left
-        text: labelText
     }
     TextField {
         id: field
@@ -27,12 +26,7 @@ Pane {
         anchors.left: label.right
         anchors.right: anchoredEditor ? parent.right : undefined
         width: 100
-        validator: pane.validator
 
-        text: editorText
-        onEditingFinished: {
-            editorText = text
-            pane.editingFinished()
-        }
+        onEditingFinished: pane.editingFinished()
     }
 }

--- a/resources/Qt models/LabeledTextField.qml
+++ b/resources/Qt models/LabeledTextField.qml
@@ -5,7 +5,8 @@ import QtQuick.Controls 2.4
 Pane {
     property string labelText: ""
     property string editorText: ""
-    property real editorWidth: 100
+    property alias editorWidth: field.width
+    property bool anchoredEditor: false
     property var validator: null
     id: pane
     padding: 2
@@ -24,7 +25,8 @@ Pane {
         focus: true
         anchors.top: parent.top
         anchors.left: label.right
-        width: editorWidth
+        anchors.right: anchoredEditor ? parent.right : undefined
+        width: 100
         validator: pane.validator
 
         text: editorText

--- a/resources/Qt models/LabeledTextField.qml
+++ b/resources/Qt models/LabeledTextField.qml
@@ -11,7 +11,7 @@ Pane {
     id: pane
     padding: 2
     contentHeight: Math.max(label.height, field.height)
-    contentWidth: label.width + field.width
+    contentWidth: label.width + (anchoredEditor ? field.implicitWidth : field.width)
     signal editingFinished
 
     Label {
@@ -25,7 +25,7 @@ Pane {
         anchors.top: parent.top
         anchors.left: label.right
         anchors.right: anchoredEditor ? parent.right : undefined
-        width: 100
+        implicitWidth: 100
 
         onEditingFinished: pane.editingFinished()
     }

--- a/resources/Qt models/Main.qml
+++ b/resources/Qt models/Main.qml
@@ -47,8 +47,6 @@ ApplicationWindow {
             anchors.bottom: parent.bottom
             anchors.left: parent.left
             leftPadding: 0
-
-            width: 400;
         }
 
         Frame {

--- a/resources/Qt models/Main.qml
+++ b/resources/Qt models/Main.qml
@@ -13,6 +13,8 @@ ApplicationWindow {
     visible: true
     width: 1100
     height: 500
+    minimumWidth: windowPane.implicitWidth
+    minimumHeight: menuBar.implicitHeight + windowPane.implicitHeight
 
     menuBar: MenuBar {
         Menu {
@@ -37,9 +39,12 @@ ApplicationWindow {
     }
 
     Pane {
+        id: windowPane
         padding: 5
         focus: true
         anchors.fill: parent
+        contentWidth: componentFieldsArea.implicitWidth + instrumentViewArea.implicitWidth + jsonPane.implicitWidth
+        contentHeight: Math.max(componentFieldsArea.implicitHeight, instrumentViewArea.implicitHeight, jsonPane.implicitHeight)
 
         ComponentControls {
             id: componentFieldsArea
@@ -55,8 +60,8 @@ ApplicationWindow {
             anchors.bottom: parent.bottom
             anchors.left: componentFieldsArea.right
             anchors.right: jsonPane.left
-            contentWidth: scene3d.implicitWidth
-            contentHeight: scene3d.implicitHeight
+            contentWidth: 100
+            contentHeight: 100
             focus: true
             padding: 1
 
@@ -84,7 +89,7 @@ ApplicationWindow {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            width: 300
+            contentWidth: 300
 
             ListView {
                 id: jsonListView

--- a/resources/Qt models/Main.qml
+++ b/resources/Qt models/Main.qml
@@ -38,6 +38,22 @@ ApplicationWindow {
         }
     }
 
+    function positionChildWindow(child) {
+        // position child window in the center of the main window
+        var centralX = window.x + ((window.width - child.width) / 2)
+        var centralY = window.y + ((window.height - child.height) / 2)
+        // if that's offscreen, position its upper left corner in center of the screen
+        var screenX = centralX - window.screen.virtualX
+        var screenY = centralY - window.screen.virtualY
+        if (screenX > window.screen.width || screenY > window.screen.height || screenX < 0 || screenY < 0){
+            centralX = window.screen.width / 2
+            centralY = window.screen.height / 2
+        }
+
+        child.x = centralX
+        child.y = centralY
+    }
+
     Pane {
         id: windowPane
         padding: 5

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -60,7 +60,7 @@ Item {
             LabeledTextField {
                 id: rowsField
                 anchors.top: parent.top
-                anchors.left: parent.left
+                anchors.right: columnsField.right
                 labelText: "Rows:"
                 editorText: rows
                 onEditingFinished: rows = parseInt(editorText)
@@ -69,7 +69,7 @@ Item {
             LabeledTextField {
                 id: rowHeightField
                 anchors.top: rowsField.top
-                anchors.left: rowsField.right
+                anchors.right: columnWidthField.right
                 labelText: "Row height:"
                 editorText: row_height
                 onEditingFinished: row_height = parseFloat(editorText)
@@ -98,7 +98,7 @@ Item {
             LabeledTextField {
                 id: firstIdField
                 anchors.top: columnWidthField.bottom
-                anchors.left: parent.left
+                anchors.right: columnsField.right
                 labelText: "First ID:"
                 editorText: first_id
                 onEditingFinished: first_id = parseInt(editorText)
@@ -128,13 +128,13 @@ Item {
             Label {
                 id: directionLabel
                 anchors.verticalCenter: directionPicker.verticalCenter
-                anchors.left: parent.left
+                anchors.right: cornerLabel.right
                 text: "Count first along:"
             }
             ComboBox {
                 id: directionPicker
                 anchors.top: cornerPicker.bottom
-                anchors.left: directionLabel.right
+                anchors.left: cornerPicker.left
                 textRole: "key"
                 model: ListModel {
                     ListElement { key: "Rows"; value: "ROW" }

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -1,0 +1,195 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import MyModels 1.0
+import MyValidators 1.0
+
+Item {
+    property var pixelModel
+
+    id: pane
+    height: view.height
+
+    function restartMapping(geometryModel){
+        onGeometryModelChanged: mappingModel.restart_mapping(geometryModel)
+    }
+
+    ListView {
+        id: view
+        height: contentHeight
+        width: parent.width
+        interactive: false
+        clip: true
+    }
+
+    PixelGridModel {
+        id: gridModel
+    }
+
+    PixelMappingModel {
+        id: mappingModel
+    }
+
+    Component {
+        id: gridDelegate
+
+        Item {
+            width: view.width
+            height: gridLabel.height + gridFields.height
+
+            Label {
+                id: gridLabel
+                anchors.top: parent.top
+                anchors.left: parent.left
+                text: "Pixel Grid:"
+            }
+
+            Frame {
+                id: gridFields
+                anchors.top: gridLabel.bottom
+                contentHeight: rowsField.height +
+                    columnsField.height +
+                    firstIdField.height +
+                    cornerPicker.height +
+                    directionPicker.height
+                width: parent.width
+
+                LabeledTextField {
+                    id: rowsField
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    labelText: "Rows:"
+                    editorText: rows
+                    onEditingFinished: rows = parseInt(editorText)
+                    validator: integerValidator
+                }
+                LabeledTextField {
+                    id: rowHeightField
+                    anchors.top: rowsField.top
+                    anchors.left: rowsField.right
+                    labelText: "Row height:"
+                    editorText: row_height
+                    onEditingFinished: row_height = parseFloat(editorText)
+                    validator: numberValidator
+                }
+
+                LabeledTextField {
+                    id: columnsField
+                    anchors.top: rowHeightField.bottom
+                    anchors.left: parent.left
+                    labelText: "Columns:"
+                    editorText: columns
+                    onEditingFinished: columns = parseInt(editorText)
+                    validator: integerValidator
+                }
+                LabeledTextField {
+                    id: columnWidthField
+                    anchors.top: columnsField.top
+                    anchors.left: columnsField.right
+                    labelText: "Column width:"
+                    editorText: col_width
+                    onEditingFinished: col_width = parseFloat(editorText)
+                    validator: numberValidator
+                }
+
+                LabeledTextField {
+                    id: firstIdField
+                    anchors.top: columnWidthField.bottom
+                    anchors.left: parent.left
+                    labelText: "First ID:"
+                    editorText: first_id
+                    onEditingFinished: first_id = parseInt(editorText)
+                    validator: integerValidator
+                }
+
+                Label {
+                    id: cornerLabel
+                    anchors.verticalCenter: cornerPicker.verticalCenter
+                    anchors.left: parent.left
+                    text: "Start counting ID's from:"
+                }
+                ComboBox {
+                    id: cornerPicker
+                    anchors.top: firstIdField.bottom
+                    anchors.left: cornerLabel.right
+                    textRole: "key"
+                    model: ListModel {
+                        ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
+                        ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
+                        ListElement { key: "Top left"; value: "TOP_LEFT" }
+                        ListElement { key: "Top right"; value: "TOP_RIGHT" }
+                    }
+                    onActivated: initial_count_corner = model.get(currentIndex).value
+                }
+
+                Label {
+                    id: directionLabel
+                    anchors.verticalCenter: directionPicker.verticalCenter
+                    anchors.left: parent.left
+                    text: "Count first along:"
+                }
+                ComboBox {
+                    id: directionPicker
+                    anchors.top: cornerPicker.bottom
+                    anchors.left: directionLabel.right
+                    textRole: "key"
+                    model: ListModel {
+                        ListElement { key: "Rows"; value: "ROW" }
+                        ListElement { key: "Columns"; value: "COLUMN" }
+                    }
+                    onActivated: count_direction = model.get(currentIndex).value
+                }
+            }
+        }
+    }
+
+    Component {
+        id: mappingDelegate
+
+        Frame {
+            width: view.width
+            contentHeight: pixelIdField.height
+            padding: 2
+
+            LabeledTextField {
+                id: pixelIdField
+                labelText: "Pixel ID for face no. " + index + ":"
+                editorText: pixel_id == null ? "" : pixel_id
+                onEditingFinished: pixel_id = parseInt(editorText)
+                validator: nullableIntValidator
+            }
+        }
+    }
+
+    NullableIntValidator {
+        id: nullableIntValidator
+        bottom: 0
+    }
+
+    IntValidator {
+        id: integerValidator
+        bottom: 0
+    }
+
+    DoubleValidator {
+        id: numberValidator
+        notation: DoubleValidator.StandardNotation
+    }
+
+    states: [
+        State {
+            name: "Grid"
+            PropertyChanges { target: pane; pixelModel: gridModel }
+            PropertyChanges { target: view; model: gridModel }
+            PropertyChanges { target: view; delegate: gridDelegate }
+        },
+        State {
+            name: "Mapping"
+            PropertyChanges { target: pane; pixelModel: mappingModel }
+            PropertyChanges { target: view; model: mappingModel }
+            PropertyChanges { target: view; delegate: mappingDelegate }
+            PropertyChanges { target: view; height: 200 }
+            PropertyChanges { target: view; interactive: true }
+        }
+    ]
+
+}

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -8,6 +8,8 @@ Item {
 
     id: pane
     height: pixelLabel.height + viewFrame.height
+    width: viewFrame.width
+    implicitWidth: viewFrame.implicitWidth
 
     signal layoutChanged()
 
@@ -24,13 +26,16 @@ Item {
     Frame {
         id: viewFrame
         anchors.top: pixelLabel.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
         contentHeight: view.height
-        width: parent.width
+        contentWidth: view.implicitWidth
         padding: 1
         ListView {
             id: view
+            anchors.left: parent.left
+            anchors.right: parent.right
             height: contentHeight
-            width: parent.width
             interactive: false
             clip: true
         }
@@ -50,12 +55,18 @@ Item {
 
         Pane {
             id: gridFields
+            width: view.width
             contentHeight: rowsField.height +
                 columnsField.height +
                 firstIdField.height +
                 cornerPicker.height +
                 directionPicker.height
-            width: view.width
+            contentWidth: Math.max(
+                rowsField.implicitWidth + rowHeightField.implicitWidth,
+                columnsField.implicitWidth + columnWidthField.implicitWidth
+            )
+
+            Component.onCompleted: view.implicitWidth = gridFields.implicitWidth
 
             LabeledTextField {
                 id: rowsField
@@ -149,9 +160,13 @@ Item {
         id: mappingDelegate
 
         Frame {
+            id: mappingItem
             width: view.width
-            contentHeight: pixelIdField.height
+            contentWidth: pixelIdField.implicitWidth
+            contentHeight: pixelIdField.implicitHeight
             padding: 2
+
+            Component.onCompleted: view.implicitWidth = mappingItem.implicitWidth
 
             LabeledTextField {
                 id: pixelIdField

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -9,6 +9,8 @@ Item {
     id: pane
     height: pixelLabel.height + viewFrame.height
 
+    signal layoutChanged()
+
     function restartMapping(geometryModel){
         onGeometryModelChanged: mappingModel.restart_mapping(geometryModel)
     }
@@ -36,6 +38,7 @@ Item {
 
     PixelGridModel {
         id: gridModel
+        onDataChanged: pane.layoutChanged()
     }
 
     PixelMappingModel {

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -7,18 +7,32 @@ Item {
     property var pixelModel
 
     id: pane
-    height: view.height
+    height: pixelLabel.height + viewFrame.height
 
     function restartMapping(geometryModel){
         onGeometryModelChanged: mappingModel.restart_mapping(geometryModel)
     }
 
-    ListView {
-        id: view
-        height: contentHeight
+    Label {
+        id: pixelLabel
+        anchors.top: parent.top
+        anchors.left: parent.left
+    }
+
+    Frame {
+        id: viewFrame
+        anchors.top: pixelLabel.bottom
+        contentHeight: view.height
         width: parent.width
-        interactive: false
-        clip: true
+        padding: 1
+        ListView {
+            id: view
+            anchors.top: pixelLabel.bottom
+            height: contentHeight
+            width: parent.width
+            interactive: false
+            clip: true
+        }
     }
 
     PixelGridModel {
@@ -32,112 +46,99 @@ Item {
     Component {
         id: gridDelegate
 
-        Item {
+        Pane {
+            id: gridFields
+            contentHeight: rowsField.height +
+                columnsField.height +
+                firstIdField.height +
+                cornerPicker.height +
+                directionPicker.height
             width: view.width
-            height: gridLabel.height + gridFields.height
 
-            Label {
-                id: gridLabel
+            LabeledTextField {
+                id: rowsField
                 anchors.top: parent.top
                 anchors.left: parent.left
-                text: "Pixel Grid:"
+                labelText: "Rows:"
+                editorText: rows
+                onEditingFinished: rows = parseInt(editorText)
+                validator: integerValidator
+            }
+            LabeledTextField {
+                id: rowHeightField
+                anchors.top: rowsField.top
+                anchors.left: rowsField.right
+                labelText: "Row height:"
+                editorText: row_height
+                onEditingFinished: row_height = parseFloat(editorText)
+                validator: numberValidator
             }
 
-            Frame {
-                id: gridFields
-                anchors.top: gridLabel.bottom
-                contentHeight: rowsField.height +
-                    columnsField.height +
-                    firstIdField.height +
-                    cornerPicker.height +
-                    directionPicker.height
-                width: parent.width
+            LabeledTextField {
+                id: columnsField
+                anchors.top: rowHeightField.bottom
+                anchors.left: parent.left
+                labelText: "Columns:"
+                editorText: columns
+                onEditingFinished: columns = parseInt(editorText)
+                validator: integerValidator
+            }
+            LabeledTextField {
+                id: columnWidthField
+                anchors.top: columnsField.top
+                anchors.left: columnsField.right
+                labelText: "Column width:"
+                editorText: col_width
+                onEditingFinished: col_width = parseFloat(editorText)
+                validator: numberValidator
+            }
 
-                LabeledTextField {
-                    id: rowsField
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    labelText: "Rows:"
-                    editorText: rows
-                    onEditingFinished: rows = parseInt(editorText)
-                    validator: integerValidator
-                }
-                LabeledTextField {
-                    id: rowHeightField
-                    anchors.top: rowsField.top
-                    anchors.left: rowsField.right
-                    labelText: "Row height:"
-                    editorText: row_height
-                    onEditingFinished: row_height = parseFloat(editorText)
-                    validator: numberValidator
-                }
+            LabeledTextField {
+                id: firstIdField
+                anchors.top: columnWidthField.bottom
+                anchors.left: parent.left
+                labelText: "First ID:"
+                editorText: first_id
+                onEditingFinished: first_id = parseInt(editorText)
+                validator: integerValidator
+            }
 
-                LabeledTextField {
-                    id: columnsField
-                    anchors.top: rowHeightField.bottom
-                    anchors.left: parent.left
-                    labelText: "Columns:"
-                    editorText: columns
-                    onEditingFinished: columns = parseInt(editorText)
-                    validator: integerValidator
+            Label {
+                id: cornerLabel
+                anchors.verticalCenter: cornerPicker.verticalCenter
+                anchors.left: parent.left
+                text: "Start counting ID's from:"
+            }
+            ComboBox {
+                id: cornerPicker
+                anchors.top: firstIdField.bottom
+                anchors.left: cornerLabel.right
+                textRole: "key"
+                model: ListModel {
+                    ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
+                    ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
+                    ListElement { key: "Top left"; value: "TOP_LEFT" }
+                    ListElement { key: "Top right"; value: "TOP_RIGHT" }
                 }
-                LabeledTextField {
-                    id: columnWidthField
-                    anchors.top: columnsField.top
-                    anchors.left: columnsField.right
-                    labelText: "Column width:"
-                    editorText: col_width
-                    onEditingFinished: col_width = parseFloat(editorText)
-                    validator: numberValidator
-                }
+                onActivated: initial_count_corner = model.get(currentIndex).value
+            }
 
-                LabeledTextField {
-                    id: firstIdField
-                    anchors.top: columnWidthField.bottom
-                    anchors.left: parent.left
-                    labelText: "First ID:"
-                    editorText: first_id
-                    onEditingFinished: first_id = parseInt(editorText)
-                    validator: integerValidator
+            Label {
+                id: directionLabel
+                anchors.verticalCenter: directionPicker.verticalCenter
+                anchors.left: parent.left
+                text: "Count first along:"
+            }
+            ComboBox {
+                id: directionPicker
+                anchors.top: cornerPicker.bottom
+                anchors.left: directionLabel.right
+                textRole: "key"
+                model: ListModel {
+                    ListElement { key: "Rows"; value: "ROW" }
+                    ListElement { key: "Columns"; value: "COLUMN" }
                 }
-
-                Label {
-                    id: cornerLabel
-                    anchors.verticalCenter: cornerPicker.verticalCenter
-                    anchors.left: parent.left
-                    text: "Start counting ID's from:"
-                }
-                ComboBox {
-                    id: cornerPicker
-                    anchors.top: firstIdField.bottom
-                    anchors.left: cornerLabel.right
-                    textRole: "key"
-                    model: ListModel {
-                        ListElement { key: "Bottom left"; value: "BOTTOM_LEFT" }
-                        ListElement { key: "Bottom right"; value: "BOTTOM_RIGHT" }
-                        ListElement { key: "Top left"; value: "TOP_LEFT" }
-                        ListElement { key: "Top right"; value: "TOP_RIGHT" }
-                    }
-                    onActivated: initial_count_corner = model.get(currentIndex).value
-                }
-
-                Label {
-                    id: directionLabel
-                    anchors.verticalCenter: directionPicker.verticalCenter
-                    anchors.left: parent.left
-                    text: "Count first along:"
-                }
-                ComboBox {
-                    id: directionPicker
-                    anchors.top: cornerPicker.bottom
-                    anchors.left: directionLabel.right
-                    textRole: "key"
-                    model: ListModel {
-                        ListElement { key: "Rows"; value: "ROW" }
-                        ListElement { key: "Columns"; value: "COLUMN" }
-                    }
-                    onActivated: count_direction = model.get(currentIndex).value
-                }
+                onActivated: count_direction = model.get(currentIndex).value
             }
         }
     }
@@ -181,6 +182,7 @@ Item {
             PropertyChanges { target: pane; pixelModel: gridModel }
             PropertyChanges { target: view; model: gridModel }
             PropertyChanges { target: view; delegate: gridDelegate }
+            PropertyChanges { target: pixelLabel; text: "Pixel grid:" }
         },
         State {
             name: "Mapping"
@@ -189,6 +191,7 @@ Item {
             PropertyChanges { target: view; delegate: mappingDelegate }
             PropertyChanges { target: view; height: 200 }
             PropertyChanges { target: view; interactive: true }
+            PropertyChanges { target: pixelLabel; text: "Pixel mapping:" }
         }
     ]
 

--- a/resources/Qt models/PixelControls.qml
+++ b/resources/Qt models/PixelControls.qml
@@ -27,7 +27,6 @@ Item {
         padding: 1
         ListView {
             id: view
-            anchors.top: pixelLabel.bottom
             height: contentHeight
             width: parent.width
             interactive: false

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -23,8 +23,6 @@ import MyValidators 1.0
 
 Item {
 
-    property bool autosave: false
-
     height: relativePicker.height +
             rotateLabel.height +
             xRotField.height +

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -33,52 +33,6 @@ Item {
             xField.height
     width: xRotField.width + yRotField.width + zRotField.width
 
-    function saveFields(){
-        saveParentIndex()
-        saveRotateX()
-        saveRotateY()
-        saveRotateZ()
-        saveRotateAngle()
-        saveTranslateX()
-        saveTranslateY()
-        saveTranslateZ()
-    }
-    function resetFields(){
-        relativePicker.currentIndex = transform_parent_index
-        xRotField.editorText = rotate_x
-        yRotField.editorText = rotate_y
-        zRotField.editorText = rotate_z
-        angleField.editorText = rotate_angle
-        xField.editorText = translate_x
-        yField.editorText = translate_y
-        zField.editorText = translate_z
-    }
-
-    function saveParentIndex(){
-        transform_parent_index = relativePicker.currentIndex
-    }
-    function saveRotateX(){
-        rotate_x = parseFloat(xRotField.editorText)
-    }
-    function saveRotateY(){
-        rotate_y = parseFloat(yRotField.editorText)
-    }
-    function saveRotateZ(){
-        rotate_z = parseFloat(zRotField.editorText)
-    }
-    function saveRotateAngle(){
-        rotate_angle = parseFloat(angleField.editorText)
-    }
-    function saveTranslateX(){
-        translate_x = parseFloat(xField.editorText)
-    }
-    function saveTranslateY(){
-        translate_y = parseFloat(yField.editorText)
-    }
-    function saveTranslateZ(){
-        translate_z = parseFloat(zField.editorText)
-    }
-
     Label {
         id: relativeLabel
         anchors.verticalCenter: relativePicker.verticalCenter
@@ -94,7 +48,9 @@ Item {
         currentIndex: transform_parent_index
         validator: parentValidator
         onActivated: {
-            if(!acceptableInput){
+            if(acceptableInput){
+                transform_parent_index = currentIndex
+            } else {
                 currentIndex = transform_parent_index
             }
         }
@@ -114,9 +70,7 @@ Item {
         labelText: "x:"
         editorText: rotate_x
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveRotateX()
-        }
+        onEditingFinished: rotate_x = parseFloat(editorText)
     }
     LabeledTextField {
         id: yRotField
@@ -125,9 +79,7 @@ Item {
         labelText: "y:"
         editorText: rotate_y
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveRotateY()
-        }
+        onEditingFinished: rotate_y = parseFloat(editorText)
     }
     LabeledTextField {
         id: zRotField
@@ -136,9 +88,7 @@ Item {
         labelText: "z:"
         editorText: rotate_z
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveRotateZ()
-        }
+        onEditingFinished: rotate_z = parseFloat(editorText)
     }
 
     LabeledTextField {
@@ -148,9 +98,7 @@ Item {
         labelText: "angle (degrees):"
         editorText: rotate_angle
         validator: angleValidator
-        onEditingFinished: if (autosave){
-            saveRotateAngle()
-        }
+        onEditingFinished: rotate_angle = parseFloat(editorText)
     }
 
     Label {
@@ -167,9 +115,7 @@ Item {
         labelText: "x:"
         editorText: translate_x
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveTranslateX()
-        }
+        onEditingFinished: translate_x = parseFloat(editorText)
     }
     LabeledTextField {
         id: yField
@@ -178,9 +124,7 @@ Item {
         labelText: "y:"
         editorText: translate_y
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveTranslateY()
-        }
+        onEditingFinished: translate_y = parseFloat(editorText)
     }
     LabeledTextField {
         id: zField
@@ -189,9 +133,7 @@ Item {
         labelText: "z:"
         editorText: translate_z
         validator: numberValidator
-        onEditingFinished: if (autosave){
-            saveTranslateZ()
-        }
+        onEditingFinished: translate_z = parseFloat(editorText)
     }
 
     DoubleValidator {

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -30,6 +30,7 @@ Item {
             translateLabel.height +
             xField.height
     width: xRotField.width + yRotField.width + zRotField.width
+    implicitWidth: xRotField.implicitWidth + yRotField.implicitWidth + zRotField.implicitWidth
 
     Label {
         id: relativeLabel

--- a/resources/Qt models/TransformControls.qml
+++ b/resources/Qt models/TransformControls.qml
@@ -22,6 +22,9 @@ import MyValidators 1.0
  */
 
 Item {
+
+    property bool autosave: false
+
     height: relativePicker.height +
             rotateLabel.height +
             xRotField.height +
@@ -31,14 +34,14 @@ Item {
     width: xRotField.width + yRotField.width + zRotField.width
 
     function saveFields(){
-        transform_parent_index = relativePicker.currentIndex
-        rotate_x = parseFloat(xRotField.editorText)
-        rotate_y = parseFloat(yRotField.editorText)
-        rotate_z = parseFloat(zRotField.editorText)
-        rotate_angle = parseFloat(angleField.editorText)
-        translate_x = parseFloat(xField.editorText)
-        translate_y = parseFloat(yField.editorText)
-        translate_z = parseFloat(zField.editorText)
+        saveParentIndex()
+        saveRotateX()
+        saveRotateY()
+        saveRotateZ()
+        saveRotateAngle()
+        saveTranslateX()
+        saveTranslateY()
+        saveTranslateZ()
     }
     function resetFields(){
         relativePicker.currentIndex = transform_parent_index
@@ -49,6 +52,31 @@ Item {
         xField.editorText = translate_x
         yField.editorText = translate_y
         zField.editorText = translate_z
+    }
+
+    function saveParentIndex(){
+        transform_parent_index = relativePicker.currentIndex
+    }
+    function saveRotateX(){
+        rotate_x = parseFloat(xRotField.editorText)
+    }
+    function saveRotateY(){
+        rotate_y = parseFloat(yRotField.editorText)
+    }
+    function saveRotateZ(){
+        rotate_z = parseFloat(zRotField.editorText)
+    }
+    function saveRotateAngle(){
+        rotate_angle = parseFloat(angleField.editorText)
+    }
+    function saveTranslateX(){
+        translate_x = parseFloat(xField.editorText)
+    }
+    function saveTranslateY(){
+        translate_y = parseFloat(yField.editorText)
+    }
+    function saveTranslateZ(){
+        translate_z = parseFloat(zField.editorText)
     }
 
     Label {
@@ -86,6 +114,9 @@ Item {
         labelText: "x:"
         editorText: rotate_x
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveRotateX()
+        }
     }
     LabeledTextField {
         id: yRotField
@@ -94,6 +125,9 @@ Item {
         labelText: "y:"
         editorText: rotate_y
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveRotateY()
+        }
     }
     LabeledTextField {
         id: zRotField
@@ -102,6 +136,9 @@ Item {
         labelText: "z:"
         editorText: rotate_z
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveRotateZ()
+        }
     }
 
     LabeledTextField {
@@ -111,6 +148,9 @@ Item {
         labelText: "angle (degrees):"
         editorText: rotate_angle
         validator: angleValidator
+        onEditingFinished: if (autosave){
+            saveRotateAngle()
+        }
     }
 
     Label {
@@ -127,6 +167,9 @@ Item {
         labelText: "x:"
         editorText: translate_x
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveTranslateX()
+        }
     }
     LabeledTextField {
         id: yField
@@ -135,6 +178,9 @@ Item {
         labelText: "y:"
         editorText: translate_y
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveTranslateY()
+        }
     }
     LabeledTextField {
         id: zField
@@ -143,6 +189,9 @@ Item {
         labelText: "z:"
         editorText: translate_z
         validator: numberValidator
+        onEditingFinished: if (autosave){
+            saveTranslateZ()
+        }
     }
 
     DoubleValidator {

--- a/tests/test_instrument_model.py
+++ b/tests/test_instrument_model.py
@@ -36,7 +36,6 @@ def test_replace_contents():
     model.replace_contents(replacement_data)
     assert model.rowCount() == 2
     assert model.components == replacement_data
-    assert len(model.meshes) == 2
 
 
 def test_generate_component_name():


### PR DESCRIPTION
Closes #47 

Adds controls for editing a detectors pixel information, and an editor window for already added components. Face to pixel mapping controls are impractically basic, but due to #56 and QtQuickControls 2 not having a TableView until Qt 5.12, I don't think much more can be done for that at present.

All the editor fields, both in the main and full editor windows now update the model automatically (when values are valid).

![image](https://user-images.githubusercontent.com/2938284/48723997-031ad980-ec20-11e8-8cb3-8b6e8659d93d.png)

