### PR TITLE
Disable face culling

### DIFF
--- a/geometry_constructor/off_renderer.py
+++ b/geometry_constructor/off_renderer.py
@@ -35,12 +35,6 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
                     vertex_buffer_values.append(vertex.x)
                     vertex_buffer_values.append(vertex.y)
                     vertex_buffer_values.append(vertex.z)
-                # repeat with the opposite winding to ensure the face is rendered regardless of winding in loaded model
-                for point_index in [face[0], face[i + 2], face[i + 1]]:
-                    vertex = vertices[point_index]
-                    vertex_buffer_values.append(vertex.x)
-                    vertex_buffer_values.append(vertex.y)
-                    vertex_buffer_values.append(vertex.z)
 
         normal_buffer_values = []
         for face in faces:
@@ -55,11 +49,6 @@ class QtOFFGeometry(Qt3DRender.QGeometry):
                     normal_buffer_values.append(normal.x())
                     normal_buffer_values.append(normal.y())
                     normal_buffer_values.append(normal.z())
-                # repeat with the opposite normal to ensure the face is rendered regardless of winding in loaded model
-                for j in range(3):
-                    normal_buffer_values.append(-normal.x())
-                    normal_buffer_values.append(-normal.y())
-                    normal_buffer_values.append(-normal.z())
 
         vertexBuffer = Qt3DRender.QBuffer(self)
         vertexBuffer.setData(

--- a/resources/Qt models/AnimatedEntity.qml
+++ b/resources/Qt models/AnimatedEntity.qml
@@ -47,7 +47,7 @@ Entity {
 
     PhongMaterial {
         id: greyMaterial
-        ambient: "grey"
+        ambient: "black"
         diffuse: "grey"
     }
 
@@ -60,7 +60,7 @@ Entity {
     PhongAlphaMaterial {
         id: beamMaterial
         ambient: "blue"
-        diffuse: "blue"
+        diffuse: "lightblue"
         alpha: 0.5
     }
 

--- a/resources/Qt models/AnimatedEntity.qml
+++ b/resources/Qt models/AnimatedEntity.qml
@@ -138,6 +138,7 @@ Entity {
         id: cylinderMesh
         length: 40
         radius: 2.5
+        rings: 2
     }
 
     NodeInstantiator  {

--- a/resources/Qt models/AnimatedEntity.qml
+++ b/resources/Qt models/AnimatedEntity.qml
@@ -25,9 +25,21 @@ Entity {
 
     components: [
         RenderSettings {
-            activeFrameGraph: ForwardRenderer {
-                camera: camera
-                clearColor: "lightgrey"
+            activeFrameGraph: RenderSurfaceSelector {
+                ClearBuffers {
+                    buffers: ClearBuffers.ColorDepthBuffer
+                    clearColor: "lightgrey"
+
+                    CameraSelector {
+                        camera: camera
+                        RenderStateSet {
+                            renderStates: [
+                                CullFace { mode: CullFace.NoCulling },
+                                DepthTest { depthFunction: DepthTest.LessOrEqual}
+                            ]
+                        }
+                    }
+                }
             }
         },
         InputSettings { }

--- a/resources/Qt models/AnimatedEntity.qml
+++ b/resources/Qt models/AnimatedEntity.qml
@@ -54,7 +54,7 @@ Entity {
     PhongMaterial {
         id: redMaterial
         ambient: "red"
-        diffuse: "red"
+        diffuse: "#b00"
     }
 
     PhongAlphaMaterial {

--- a/tests/test_geometry_loader.py
+++ b/tests/test_geometry_loader.py
@@ -98,8 +98,8 @@ def test_generate_off_mesh_without_repeating_grid():
                                faces=[[0, 1, 2, 3],
                                       [2, 3, 4]])
     qt_geometry = QtOFFGeometry(off_geometry, None)
-    # 2 sides per shape, 3 triangles total, 3 points per triangle
-    assert qt_geometry.vertex_count == 2 * 3 * 3
+    # 3 triangles total, 3 points per triangle
+    assert qt_geometry.vertex_count == 3 * 3
     vertex_data_bytes = eval(str(qt_geometry.attributes()[0].buffer().data()))
     vertex_data = list(struct.unpack('%sf' % (qt_geometry.vertex_count * 3), vertex_data_bytes))
     generated_triangles = [vertex_data[i:i + 9] for i in range(0, len(vertex_data), 9)]
@@ -113,10 +113,9 @@ def test_generate_off_mesh_without_repeating_grid():
                  [1, 1, 0,
                   1, 0, 0,
                   1.5, 0.5, 0]]
-    # check the triangle and its inverted winding are present
+    # check the triangles are present
     for triangle in triangles:
         assert triangle in generated_triangles
-        assert triangle[0:3] + triangle[6:9] + triangle[3:6] in generated_triangles
 
 
 def test_generate_off_mesh_with_repeating_grid():
@@ -136,8 +135,8 @@ def test_generate_off_mesh_with_repeating_grid():
                                                         row_height=row_height,
                                                         columns=columns,
                                                         col_width=column_width))
-    # rows of copies, 2 sides per shape, 3 triangles total, 3 points per triangle
-    assert qt_geometry.vertex_count == rows * columns * 2 * 3 * 3
+    # rows of copies, 3 triangles total, 3 points per triangle
+    assert qt_geometry.vertex_count == rows * columns * 3 * 3
 
     vertex_data_bytes = eval(str(qt_geometry.attributes()[0].buffer().data()))
     vertex_data = list(struct.unpack('%sf' % (qt_geometry.vertex_count * 3), vertex_data_bytes))
@@ -156,7 +155,6 @@ def test_generate_off_mesh_with_repeating_grid():
                          [1+x_offset, 1+y_offset, 0,
                           1+x_offset, 0+y_offset, 0,
                           1.5+x_offset, 0.5+y_offset, 0]]
-            # check the triangle and its inverted winding are present
+            # check the triangles are present
             for triangle in triangles:
                 assert triangle in generated_triangles
-                assert triangle[0:3] + triangle[6:9] + triangle[3:6] in generated_triangles


### PR DESCRIPTION
Closes #58 

Prior to this I'd built the graphics meshes so each triangle had an inverted winding duplicate to ensure it would be drawn from both sides. Disabling face culling makes that duplication redundant. Removing it results in speeding up mesh generation, reducing the memory consumed by the graphics buffers (12MB for a 4x3 grid of a 0.5MB STL), and giving a mild reduction in the GPU load.

There is a slight tradeoff in lighting effects if the loaded geometry file isn't built with the correct winding order. In that case, faces have inverted normals and reflect as if they're facing away from light instead of towards it, but I think this should be acceptable.

### Before:
![image](https://user-images.githubusercontent.com/2938284/48902246-ee248d00-ee4f-11e8-9def-ffec5bdaa4b2.png)


### After:
![image](https://user-images.githubusercontent.com/2938284/48902089-5fb00b80-ee4f-11e8-883c-fbf72824d524.png)
